### PR TITLE
Implement concurrent orchestrator and basic API server

### DIFF
--- a/cmd/agentrunner/main.go
+++ b/cmd/agentrunner/main.go
@@ -13,7 +13,6 @@ import (
 func main() {
 	fmt.Println("--- Agentic Flow Engine Runner ---")
 
-	// Start a lightweight local HTTP server for demo purposes.
 	srv := &http.Server{Addr: ":8081"}
 	http.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "pong")
@@ -25,7 +24,7 @@ func main() {
 
 	pipeline := orchestrator.Pipeline{
 		ID:          "simple_echo_pipeline_001",
-		Description: "A pipeline with two echo steps",
+		Description: "A pipeline with echo and HTTP steps",
 		Groups: []orchestrator.PipelineGroup{
 			{
 				Name: "initial",
@@ -42,36 +41,16 @@ func main() {
 						},
 					},
 					{
-						Name:      "step_two_echo",
-						AgentType: "EchoAgent",
+						Name:      "step_two_http",
+						AgentType: "HTTPCallAgent",
 						AgentConfig: agent.Task{
-							Description: "Second echo, uses output from step one",
+							Description: "Call local HTTP service",
 						},
 						InputMappings: map[string]string{
-							"complex_input":     fmt.Sprintf("step_one_echo.%s", orchestrator.DefaultOutputKey),
-							"original_greeting": "initial.user_greeting",
+							"url":    "initial.ping_url",
+							"method": "initial.http_method",
 						},
 					},
-				Name:      "step_one_echo",
-				AgentType: "EchoAgent",
-				AgentConfig: agent.Task{
-					Description: "First echo in the pipeline",
-				},
-				InputMappings: map[string]string{
-					"message": "initial.user_greeting",
-					"detail":  "initial.user_detail",
-				},
-			},
-			{
-				Name:      "step_two_http",
-				AgentType: "HTTPCallAgent",
-				AgentConfig: agent.Task{
-					Description: "Call local HTTP service",
-				},
-				InputMappings: map[string]string{
-					"url":    "initial.ping_url",
-					"method": "initial.http_method",
-
 				},
 			},
 		},

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"agentic.example.com/mvp/internal/orchestrator"
+)
+
+// executeRequest is the payload for POST /execute
+type executeRequest struct {
+	Pipeline     orchestrator.Pipeline  `json:"pipeline"`
+	InitialInput map[string]interface{} `json:"initial_input"`
+}
+
+type executeResponse struct {
+	Data  orchestrator.StepData `json:"data,omitempty"`
+	Error string                `json:"error,omitempty"`
+}
+
+func main() {
+	orc := orchestrator.NewOrchestrator()
+
+	http.HandleFunc("/execute", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var req executeRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		data, err := orc.ExecutePipeline(r.Context(), req.Pipeline, req.InitialInput)
+		resp := executeResponse{Data: data}
+		if err != nil {
+			resp.Error = err.Error()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	log.Println("Server listening on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/internal/agent/http_agent.go
+++ b/internal/agent/http_agent.go
@@ -12,9 +12,7 @@ import (
 	"github.com/google/uuid"
 )
 
-// HTTPCallAgent is an agent that makes HTTP requests.
-// It demonstrates how external services or tools can be plugged into
-// the orchestration layer in a code-agnostic way.
+// HTTPCallAgent is an agent that makes HTTP requests to an external service.
 type HTTPCallAgent struct {
 	agentID string
 	client  *http.Client
@@ -64,45 +62,8 @@ func (ha *HTTPCallAgent) Execute(ctx context.Context, task Task) Result {
 	}
 
 	return Result{TaskID: task.ID, Output: string(respBody), Successful: true}
-	"fmt"
-	"github.com/google/uuid"
-	"io"
-	"net/http"
-	"time"
-)
-
-// HTTPCallAgent calls an HTTP endpoint with provided parameters.
-type HTTPCallAgent struct {
-	agentID string
-}
-
-func NewHTTPCallAgent() *HTTPCallAgent {
-	return &HTTPCallAgent{agentID: fmt.Sprintf("http-agent-%s", uuid.NewString())}
-}
-
-func (h *HTTPCallAgent) ID() string { return h.agentID }
-
-func (h *HTTPCallAgent) Execute(ctx context.Context, task Task) Result {
-	url, _ := task.Input["url"].(string)
-	method, _ := task.Input["method"].(string)
-	bodyStr, _ := task.Input["body"].(string)
-	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewBufferString(bodyStr))
-	if err != nil {
-		return Result{TaskID: task.ID, Error: err}
-	}
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return Result{TaskID: task.ID, Error: err}
-	}
-	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return Result{TaskID: task.ID, Error: err}
-	}
-	return Result{TaskID: task.ID, Output: map[string]interface{}{"status": resp.StatusCode, "body": string(data)}, Successful: true}
 }
 
 func init() {
-	Register("HTTPCallAgent", func() Agent { return NewHTTPCallAgent() })
+	Register("HTTPCallAgent", func() Agent { return NewHTTPCallAgent(http.MethodGet, "", nil) })
 }


### PR DESCRIPTION
## Summary
- clean up and fix orchestrator execution logic
- streamline HTTP agent implementation
- add sample agent runner
- provide minimal HTTP server to execute pipelines

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684dab513b3c832391b543ae2aa8bd4b