### PR TITLE
Document universal MCP layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # Agentic Go Orchestration Skeleton
 
-This repository contains an experimental orchestration layer for building agent based pipelines in Go. The goal is to provide a plug–and–play framework that can host any type of agent while leveraging Go's concurrency primitives.
+This repository experiments with an extensible orchestration layer for building agent based pipelines in Go.  The design focuses on using goroutines and channels wherever possible so that every step of a pipeline can run concurrently.
+
+See [docs/architecture.md](docs/architecture.md) for a deeper architectural overview and the project roadmap. The
+[Universal MCP Layer](docs/universal_mcp.md) document explains how remote models are unified behind a single gateway.
 
 ## Features
 
-- **Agent Registry** – Agents can register themselves by name so pipelines remain decoupled from concrete implementations.
-- **Pipeline Orchestrator** – Executes a series of steps where each step invokes an agent with mapped inputs.
-- **Concurrency by Default** – Agents run in their own goroutine and communicate results via channels.
-- **Tool Interfaces** – Basic stubs for tools like embedding, retrieval and reranking are provided for future expansion.
+- **Agent Registry** – Agents register by name and can be created on demand.  Pipelines are therefore decoupled from concrete implementations.
+- **Pipeline Orchestrator** – Executes ordered groups of steps.  Steps within a group run in their own goroutine and communicate results via channels.
+- **Tool Interfaces** – Stubs for embedding, retrieval and reranking demonstrate how external capabilities plug in.
+- **HTTP Server Example** – `cmd/server` exposes pipeline execution through a simple API.
 
 ## Example
 
-See `cmd/agentrunner/main.go` for a basic pipeline using the `EchoAgent`. Additional agents can be created and registered to extend the system:
+`cmd/agentrunner/main.go` defines a small pipeline using the `EchoAgent` and an `HTTPCallAgent`:
 
 ```go
 func init() {
@@ -19,5 +22,4 @@ func init() {
 }
 ```
 
-Pipelines reference agents by name and the orchestrator will instantiate them at runtime using the registry.
-
+Pipelines reference agents by name and the orchestrator will instantiate them at runtime using the registry.  Each step's output becomes available for later steps through a shared `StepData` map.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,63 @@
+# Agentic Orchestration Architecture
+
+This document captures the overall design of the extensible Go orchestration layer.  The ideas here originate from `concept.md` and have been refined into a more concise form.
+
+## Goals
+
+- **Plug and play** – tools written in any language can be wrapped as an agent and used without knowing the rest of the system.
+- **Concurrency everywhere** – goroutines and channels drive all coordination so the engine fully utilizes Go's strengths.
+- **Composable pipelines** – each pipeline is a sequence of steps grouped into stages that can run concurrently.
+
+## Core Components
+
+### Agents
+
+An agent is any piece of logic implementing the `Execute` method defined in [`agent.go`](../internal/agent/agent.go).  The orchestrator creates agents dynamically based on the `AgentType` specified in each step.  Built‑in examples include:
+
+- `EchoAgent` – echos input and demonstrates timing control.
+- `HTTPCallAgent` – performs HTTP requests and forwards the response.
+
+Agents register themselves in a central registry so pipelines are decoupled from implementations.
+
+### Pipeline Structure
+
+Pipelines consist of ordered **groups** of steps.  Steps within a group run concurrently, each in its own goroutine, and send their results back through a channel.  The orchestrator waits for all steps in a group to finish before moving on to the next group.
+
+```go
+pipeline := orchestrator.Pipeline{
+    ID: "example",
+    Groups: []orchestrator.PipelineGroup{
+        {Name: "fetch", Steps: []orchestrator.PipelineStep{/* ... */}},
+        {Name: "process", Steps: []orchestrator.PipelineStep{/* ... */}},
+    },
+}
+```
+
+### Concurrency Model
+
+Each step result is sent over a channel to the orchestrator.  This isolation makes it straightforward to introduce fan‑in or fan‑out patterns as the engine grows.  The design emphasises using goroutines and channels *any time possible* to keep the system responsive and scalable.
+
+### Extensibility
+
+Agents can live in separate repositories or services.  As long as they expose an HTTP interface or a small Go wrapper, they are usable by the engine.  This makes the orchestration layer language agnostic while still benefiting from Go's runtime.
+
+### Universal MCP Layer
+
+The **Master Control Program (MCP)** acts as a consolidated gateway for all remote models and tools. Instead of calling services directly, agents contact the MCP which routes each request to the correct adapter. See [universal_mcp.md](universal_mcp.md) for a complete design. The MCP provides:
+
+- A uniform HTTP interface for invoking external capabilities.
+- Adapter plugins that translate between generic task payloads and model-specific APIs.
+- Concurrent handling so heavy model calls do not block others.
+- Logging and metrics around every request.
+
+## Planned Features and Roadmap
+
+1. **HTTP Service** – expose pipeline execution through an API so other languages can dispatch tasks.
+2. **Task State Tracking** – persist intermediate results for debugging and retrieval via API.
+3. **Additional Agent Types**
+   - Retrieval and embedding agents for working with vector stores.
+   - Reranking and document attachment agents.
+4. **Observability Improvements** – structured logging, tracing and metrics around each step.
+5. **Configuration Loading** – ability to define pipelines and agent parameters from YAML or JSON files.
+
+These items build on the skeleton currently in the repository and align with the direction outlined in `concept.md`.

--- a/docs/universal_mcp.md
+++ b/docs/universal_mcp.md
@@ -1,0 +1,50 @@
+# Universal MCP Layer
+
+The **Master Control Program (MCP)** provides a central gateway for executing remote models and tools regardless of where they live. It standardizes how the orchestrator communicates with external services.
+
+## Purpose
+
+- **Unify Remote Calls** – Whether invoking a local Python script, a containerized service or a cloud LLM, the MCP exposes a consistent HTTP interface.
+- **Language Agnostic** – Clients written in any language send a task description and receive structured results. Internally the MCP proxies the request to the correct backend.
+- **Concurrent Handling** – The MCP is written in Go so each inbound request is handled in its own goroutine. Long‐running model invocations cannot block others.
+
+## Core Features
+
+1. **Adapter Plugins**
+    - Each external tool is wrapped by an adapter implementing a common interface.
+    - Adapters translate generic task payloads into the target system’s API format and back again.
+2. **Routing Logic**
+    - Requests specify the desired adapter by name. The MCP routes the payload to the matching adapter.
+    - Defaults and fallbacks allow one tool to substitute for another when needed.
+3. **Streaming Support**
+    - For LLMs or tools that produce incremental output, adapters may stream results over HTTP using server‑sent events or WebSockets.
+4. **Observability Hooks**
+    - Every request/response pair is logged with timing and optional trace IDs.
+    - Metrics can be exported to Prometheus or other monitoring systems.
+5. **Auth and Rate Limiting**
+    - Basic authentication and per‑adapter rate limits protect remote services from abuse.
+
+## Usage Within the Orchestrator
+
+The orchestrator’s `HTTPCallAgent` interacts with the MCP rather than calling tools directly. Pipelines simply specify which MCP adapter to use and supply any necessary parameters. This keeps step definitions clean and allows tools to be swapped without changing pipeline code.
+
+```yaml
+# Example pipeline snippet referencing an MCP adapter
+- step_name: generate_answer
+  agent_type: HTTPCallAgent
+  config:
+    url: http://localhost:8000/mcp/invoke/claude
+    method: POST
+    payload_template:
+      query: "$.initial_input.user_query"
+```
+
+## Roadmap
+
+- **Adapter Library** – Build adapters for common model providers (Claude, OpenAI, local embeddings engines).
+- **Central Configuration** – YAML or JSON file mapping adapter names to their endpoints and auth credentials.
+- **Caching** – Optional result caching to speed up repeated requests.
+- **CLI Utilities** – Commands for registering new adapters and health checking.
+
+The MCP layer serves as the universal glue between the Go orchestration engine and any external capability. Adding a new model becomes a matter of writing a small adapter while the core pipeline logic remains unchanged.
+

--- a/structure.md
+++ b/structure.md
@@ -1,12 +1,27 @@
-go-agentic-mvp/
-├── go.mod
-├── go.sum // Will be updated as we add dependencies or run 'go mod tidy'
+agentic-go/
 ├── cmd/
-│ └── agentrunner/ // Our main application executable will be built from here
-│ └── main.go // The entry point for our application
+│   ├── agentrunner/        # Example application executing a pipeline
+│   │   └── main.go
+│   └── server/             # HTTP server exposing pipeline execution
+│       └── main.go
 ├── internal/
-│ └── agent/ // Core agent logic (e.g., Agent interface, implementations)
-│ └── agent.go // We'll define our first agent constructs here
-│ └── orchestrator/ // Logic for managing and coordinating agents (we'll add this later)
-│ └── orchestrator.go
-└── README.md // (Good practice to have one)
+│   ├── agent/              # Core agent interface and implementations
+│   │   ├── agent.go
+│   │   ├── http_agent.go
+│   │   └── registry.go
+│   ├── orchestrator/       # Pipeline and orchestrator logic
+│   │   ├── orchestrator.go
+│   │   └── pipeline.go
+│   └── tools/              # Stubs for embedding, retrieval, reranking
+│       ├── embedding.go
+│       ├── rerank.go
+│       ├── retrieval.go
+│       └── tool.go
+├── docs/                   # Project documentation
+│   ├── architecture.md
+│   └── universal_mcp.md
+├── concept.md              # Original notes and design discussion
+├── README.md
+├── structure.md            # This file
+├── go.mod
+└── go.sum


### PR DESCRIPTION
## Summary
- link universal MCP details from the README
- describe the MCP gateway in the architecture doc
- add new documentation for the MCP layer
- update project structure diagram

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684daf76bdec832392efc24a1be1eb3e