### PR TITLE
Add DataTransformAgent and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ See [docs/architecture.md](docs/architecture.md) for a deeper architectural over
 - **Pipeline Orchestrator** – Executes ordered groups of steps.  Steps within a group run in their own goroutine and communicate results via channels.
 - **Tool Interfaces** – Stubs for embedding, retrieval and reranking demonstrate how external capabilities plug in.
 - **HTTP Server Example** – `cmd/server` exposes pipeline execution through a simple API.
+- **Data Transform Agent** – Performs basic string manipulation operations.
 
 ## Example
 
@@ -27,3 +28,30 @@ func init() {
 ```
 
 Pipelines reference agents by name and the orchestrator will instantiate them at runtime using the registry.  Each step's output becomes available for later steps through a shared `StepData` map.
+
+### Example Pipeline with `DataTransformAgent`
+
+The `DataTransformAgent` manipulates text according to an `operation` value.
+Supported operations are `uppercase`, `lowercase`, `reverse`, and `title`.
+
+```go
+pipeline := orchestrator.Pipeline{
+    ID: "string_pipeline",
+    Groups: []orchestrator.PipelineGroup{
+        {
+            Name: "transform",
+            Steps: []orchestrator.PipelineStep{
+                {
+                    Name:      "make_upper",
+                    AgentType: "DataTransformAgent",
+                    AgentConfig: agent.Task{Description: "Uppercase the text"},
+                    InputMappings: map[string]string{
+                        "text":      "initial.input_text",
+                        "operation": "initial.op",
+                    },
+                },
+            },
+        },
+    },
+}
+```

--- a/internal/agent/data_transform_agent.go
+++ b/internal/agent/data_transform_agent.go
@@ -1,0 +1,62 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// DataTransformAgent performs simple string manipulations on the provided input.
+type DataTransformAgent struct {
+	agentID string
+}
+
+// NewDataTransformAgent creates a new DataTransformAgent.
+func NewDataTransformAgent() *DataTransformAgent {
+	return &DataTransformAgent{agentID: fmt.Sprintf("transform-agent-%s", uuid.NewString())}
+}
+
+// ID implements the Agent interface.
+func (d *DataTransformAgent) ID() string { return d.agentID }
+
+// Execute applies the requested operation to the input string.
+// Supported operations: "uppercase", "lowercase", "reverse", "title".
+// Defaults to "uppercase" when no operation is provided.
+func (d *DataTransformAgent) Execute(ctx context.Context, task Task) Result {
+	text, _ := task.Input["text"].(string)
+	op, _ := task.Input["operation"].(string)
+	if op == "" {
+		op = "uppercase"
+	}
+
+	var out string
+	switch op {
+	case "uppercase":
+		out = strings.ToUpper(text)
+	case "lowercase":
+		out = strings.ToLower(text)
+	case "reverse":
+		r := []rune(text)
+		for i, j := 0, len(r)-1; i < j; i, j = i+1, j-1 {
+			r[i], r[j] = r[j], r[i]
+		}
+		out = string(r)
+	case "title":
+		out = strings.Title(text)
+	default:
+		out = text
+	}
+
+	result := map[string]interface{}{
+		"operation": op,
+		"output":    out,
+	}
+
+	return Result{TaskID: task.ID, Output: result, Successful: true}
+}
+
+func init() {
+	Register("DataTransformAgent", func() Agent { return NewDataTransformAgent() })
+}


### PR DESCRIPTION
## Summary
- add `DataTransformAgent` with basic string operations
- document the agent and show example pipeline usage

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684dbabddc148323b26905548edf8d5a