### PR TITLE
Implement basic vector store and tools

### DIFF
--- a/docs/vector_pipeline.md
+++ b/docs/vector_pipeline.md
@@ -1,0 +1,41 @@
+# Vector Pipeline Components
+
+This document describes the initial implementation of the embedding, storage,
+retrieval and reranking pieces of the agentic pipeline.
+
+## Overview
+
+The pipeline now exposes dedicated agents and tools to work with a vector store.
+All data is stored through the `vectorstore` package which currently provides
+an in-memory implementation for local testing.  Each piece is designed to be
+swappable with a production ready backend.
+
+### Packages
+
+* `internal/vectorstore` – Defines the `VectorStore` interface and a basic
+  `MemoryStore` used for early testing.
+* `internal/tools` – Contains tools implementing the common `Tool` interface:
+  * `EmbeddingTool` – generates deterministic embeddings.
+  * `RetrievalTool` – queries a `VectorStore` for similar documents.
+  * `RerankTool` – orders documents by score.
+* `internal/agent` – Agents wrapping the tools so they can run as pipeline steps:
+  * `EmbeddingAgent`
+  * `RetrievalAgent`
+  * `RerankAgent`
+
+## Remaining Work
+
+1. **Persistent Vector Store** – replace `MemoryStore` with a production ready
+   database (e.g. Qdrant or Weaviate) behind the same interface.
+2. **Real Embedding Model** – integrate with an actual embedding service or
+   model. The current hash-based embedding is deterministic but not meaningful.
+3. **Scoring for Reranking** – the rerank agent assumes a `score` field. A
+   real implementation should compute scores based on query context and document
+   relevance.
+4. **Configuration** – allow pipeline definitions to specify which vector store
+   to use and embed model parameters.
+5. **Metrics & Error Handling** – add logging and observability hooks around
+   vector operations.
+
+These steps will take the foundation here to a live-ready state while keeping the
+API surface stable.

--- a/internal/agent/embedding_agent.go
+++ b/internal/agent/embedding_agent.go
@@ -1,0 +1,46 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"agentic.example.com/mvp/internal/tools"
+	"agentic.example.com/mvp/internal/vectorstore"
+)
+
+// EmbeddingAgent generates embeddings and stores them in the vector store.
+type EmbeddingAgent struct {
+	id    string
+	store vectorstore.VectorStore
+	tool  *tools.EmbeddingTool
+}
+
+// NewEmbeddingAgent returns a new EmbeddingAgent using the default store.
+func NewEmbeddingAgent() *EmbeddingAgent {
+	return &EmbeddingAgent{
+		id:    fmt.Sprintf("embedding-agent-%s", uuid.NewString()),
+		store: vectorstore.DefaultStore(),
+		tool:  tools.NewEmbeddingTool(128),
+	}
+}
+
+func (e *EmbeddingAgent) ID() string { return e.id }
+
+func (e *EmbeddingAgent) Execute(ctx context.Context, task Task) Result {
+	out, err := e.tool.Run(ctx, task.Input)
+	if err != nil {
+		return Result{TaskID: task.ID, Error: err}
+	}
+	emb := out["embedding"].([]float64)
+	if e.store != nil {
+		doc := vectorstore.Document{ID: task.ID, Embedding: emb, Metadata: task.Input}
+		e.store.Upsert(ctx, []vectorstore.Document{doc})
+	}
+	return Result{TaskID: task.ID, Output: out, Successful: true}
+}
+
+func init() {
+	Register("EmbeddingAgent", func() Agent { return NewEmbeddingAgent() })
+}

--- a/internal/agent/rerank_agent.go
+++ b/internal/agent/rerank_agent.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"agentic.example.com/mvp/internal/tools"
+)
+
+// RerankAgent orders documents based on score.
+type RerankAgent struct {
+	id   string
+	tool *tools.RerankTool
+}
+
+func NewRerankAgent() *RerankAgent {
+	return &RerankAgent{id: fmt.Sprintf("rerank-agent-%s", uuid.NewString()), tool: tools.NewRerankTool()}
+}
+
+func (r *RerankAgent) ID() string { return r.id }
+
+func (r *RerankAgent) Execute(ctx context.Context, task Task) Result {
+	out, err := r.tool.Run(ctx, task.Input)
+	if err != nil {
+		return Result{TaskID: task.ID, Error: err}
+	}
+	return Result{TaskID: task.ID, Output: out, Successful: true}
+}
+
+func init() {
+	Register("RerankAgent", func() Agent { return NewRerankAgent() })
+}

--- a/internal/agent/retrieval_agent.go
+++ b/internal/agent/retrieval_agent.go
@@ -1,0 +1,39 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"agentic.example.com/mvp/internal/tools"
+	"agentic.example.com/mvp/internal/vectorstore"
+)
+
+// RetrievalAgent queries the vector store for similar documents.
+type RetrievalAgent struct {
+	id   string
+	tool *tools.RetrievalTool
+}
+
+// NewRetrievalAgent creates a RetrievalAgent using the default store.
+func NewRetrievalAgent() *RetrievalAgent {
+	return &RetrievalAgent{
+		id:   fmt.Sprintf("retrieval-agent-%s", uuid.NewString()),
+		tool: tools.NewRetrievalTool(vectorstore.DefaultStore(), 5),
+	}
+}
+
+func (r *RetrievalAgent) ID() string { return r.id }
+
+func (r *RetrievalAgent) Execute(ctx context.Context, task Task) Result {
+	out, err := r.tool.Run(ctx, task.Input)
+	if err != nil {
+		return Result{TaskID: task.ID, Error: err}
+	}
+	return Result{TaskID: task.ID, Output: out, Successful: true}
+}
+
+func init() {
+	Register("RetrievalAgent", func() Agent { return NewRetrievalAgent() })
+}

--- a/internal/tools/embedding.go
+++ b/internal/tools/embedding.go
@@ -2,16 +2,37 @@ package tools
 
 import (
 	"context"
-	"fmt"
+	"errors"
+	"hash/fnv"
+	"strings"
 )
 
-// EmbeddingTool is a stub that would call an embedding model or service.
-func EmbeddingTool(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {
-	// Placeholder implementation
-	text, _ := input["text"].(string)
-	// Simulate computed embeddings
-	result := map[string]interface{}{
-		"embedding": fmt.Sprintf("embedding_of_%s", text),
+// BasicHashEmbed generates a deterministic embedding vector of fixed dimension.
+func BasicHashEmbed(text string, dim int) []float64 {
+	vec := make([]float64, dim)
+	for _, w := range strings.Fields(strings.ToLower(text)) {
+		h := fnv.New32a()
+		h.Write([]byte(w))
+		idx := int(h.Sum32()) % dim
+		vec[idx] += 1
 	}
-	return result, nil
+	return vec
+}
+
+// EmbeddingTool produces embeddings for provided text.
+type EmbeddingTool struct {
+	Dim int
+}
+
+// NewEmbeddingTool returns an EmbeddingTool with the given dimension.
+func NewEmbeddingTool(dim int) *EmbeddingTool { return &EmbeddingTool{Dim: dim} }
+
+// Run implements the Tool interface.
+func (e *EmbeddingTool) Run(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {
+	txt, _ := input["text"].(string)
+	if txt == "" {
+		return nil, errors.New("text field required")
+	}
+	emb := BasicHashEmbed(txt, e.Dim)
+	return map[string]interface{}{"embedding": emb}, nil
 }

--- a/internal/tools/embedding_test.go
+++ b/internal/tools/embedding_test.go
@@ -1,0 +1,16 @@
+package tools
+
+import "testing"
+
+func TestBasicHashEmbed(t *testing.T) {
+	v1 := BasicHashEmbed("hello world", 10)
+	v2 := BasicHashEmbed("hello world", 10)
+	if len(v1) != 10 || len(v2) != 10 {
+		t.Fatalf("unexpected dimension")
+	}
+	for i := range v1 {
+		if v1[i] != v2[i] {
+			t.Fatalf("embedding not deterministic")
+		}
+	}
+}

--- a/internal/tools/rerank.go
+++ b/internal/tools/rerank.go
@@ -2,14 +2,27 @@ package tools
 
 import (
 	"context"
-	"fmt"
+	"errors"
+	"sort"
 )
 
-// RerankTool is a stub for reranking documents.
-func RerankTool(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {
-	docs, _ := input["documents"].([]string)
-	result := map[string]interface{}{
-		"reranked": fmt.Sprintf("reranked_%d_docs", len(docs)),
+// RerankTool sorts documents based on a provided score field.
+type RerankTool struct{}
+
+// NewRerankTool creates a simple RerankTool.
+func NewRerankTool() *RerankTool { return &RerankTool{} }
+
+// Run implements the Tool interface. Input expects `documents` as slice of maps
+// with a numeric `score` field.
+func (r *RerankTool) Run(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {
+	docs, ok := input["documents"].([]map[string]interface{})
+	if !ok {
+		return nil, errors.New("documents must be provided")
 	}
-	return result, nil
+	sort.Slice(docs, func(i, j int) bool {
+		si, _ := docs[i]["score"].(float64)
+		sj, _ := docs[j]["score"].(float64)
+		return si > sj
+	})
+	return map[string]interface{}{"reranked": docs}, nil
 }

--- a/internal/tools/rerank_test.go
+++ b/internal/tools/rerank_test.go
@@ -1,0 +1,16 @@
+package tools
+
+import "testing"
+
+func TestRerankTool(t *testing.T) {
+	tool := NewRerankTool()
+	docs := []map[string]interface{}{{"id": "a", "score": 0.1}, {"id": "b", "score": 0.9}}
+	out, err := tool.Run(nil, map[string]interface{}{"documents": docs})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	r := out["reranked"].([]map[string]interface{})
+	if r[0]["id"] != "b" {
+		t.Fatalf("unexpected order: %+v", r)
+	}
+}

--- a/internal/tools/retrieval.go
+++ b/internal/tools/retrieval.go
@@ -2,14 +2,44 @@ package tools
 
 import (
 	"context"
-	"fmt"
+	"errors"
+
+	"agentic.example.com/mvp/internal/vectorstore"
 )
 
-// RetrievalTool is a stub that would query an index or database.
-func RetrievalTool(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {
-	query, _ := input["query"].(string)
-	result := map[string]interface{}{
-		"documents": []string{fmt.Sprintf("doc_for_%s", query)},
+// RetrievalTool retrieves nearest documents from a vector store.
+type RetrievalTool struct {
+	Store vectorstore.VectorStore
+	TopK  int
+}
+
+// NewRetrievalTool constructs a RetrievalTool.
+func NewRetrievalTool(store vectorstore.VectorStore, k int) *RetrievalTool {
+	if k <= 0 {
+		k = 5
 	}
-	return result, nil
+	return &RetrievalTool{Store: store, TopK: k}
+}
+
+// Run implements the Tool interface.
+func (r *RetrievalTool) Run(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {
+	emb, ok := input["embedding"].([]float64)
+	if !ok || len(emb) == 0 {
+		return nil, errors.New("embedding required")
+	}
+	if r.Store == nil {
+		r.Store = vectorstore.DefaultStore()
+	}
+	docs, err := r.Store.Query(ctx, emb, r.TopK)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]map[string]interface{}, len(docs))
+	for i, d := range docs {
+		out[i] = map[string]interface{}{
+			"id":       d.ID,
+			"metadata": d.Metadata,
+		}
+	}
+	return map[string]interface{}{"documents": out}, nil
 }

--- a/internal/tools/retrieval_test.go
+++ b/internal/tools/retrieval_test.go
@@ -1,0 +1,23 @@
+package tools
+
+import (
+	"testing"
+
+	"agentic.example.com/mvp/internal/vectorstore"
+)
+
+func TestRetrievalTool(t *testing.T) {
+	store := vectorstore.NewMemoryStore()
+	vectorstore.SetDefaultStore(store)
+	emb := BasicHashEmbed("hello", 8)
+	store.Upsert(nil, []vectorstore.Document{{ID: "1", Embedding: emb}})
+	tool := NewRetrievalTool(store, 1)
+	out, err := tool.Run(nil, map[string]interface{}{"embedding": emb})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	docs := out["documents"].([]map[string]interface{})
+	if len(docs) != 1 || docs[0]["id"] != "1" {
+		t.Fatalf("unexpected result: %+v", out)
+	}
+}

--- a/internal/vectorstore/memstore.go
+++ b/internal/vectorstore/memstore.go
@@ -1,0 +1,80 @@
+package vectorstore
+
+import (
+	"context"
+	"math"
+	"sort"
+	"sync"
+)
+
+// MemoryStore provides an in-memory implementation of VectorStore.
+type MemoryStore struct {
+	mu   sync.RWMutex
+	docs []Document
+}
+
+// NewMemoryStore returns a new MemoryStore.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{}
+}
+
+// Upsert adds or replaces documents based on ID.
+func (m *MemoryStore) Upsert(ctx context.Context, docs []Document) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, d := range docs {
+		replaced := false
+		for i, existing := range m.docs {
+			if existing.ID == d.ID {
+				m.docs[i] = d
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			m.docs = append(m.docs, d)
+		}
+	}
+	return nil
+}
+
+// cosineSimilarity returns similarity between two vectors.
+func cosineSimilarity(a, b []float64) float64 {
+	if len(a) != len(b) {
+		return 0
+	}
+	var dot, normA, normB float64
+	for i := range a {
+		dot += a[i] * b[i]
+		normA += a[i] * a[i]
+		normB += b[i] * b[i]
+	}
+	if normA == 0 || normB == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(normA) * math.Sqrt(normB))
+}
+
+// Query returns the k most similar documents.
+func (m *MemoryStore) Query(ctx context.Context, emb []float64, k int) ([]Document, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	type scored struct {
+		doc   Document
+		score float64
+	}
+	var scoredDocs []scored
+	for _, d := range m.docs {
+		s := cosineSimilarity(d.Embedding, emb)
+		scoredDocs = append(scoredDocs, scored{doc: d, score: s})
+	}
+	sort.Slice(scoredDocs, func(i, j int) bool { return scoredDocs[i].score > scoredDocs[j].score })
+	if k > len(scoredDocs) {
+		k = len(scoredDocs)
+	}
+	result := make([]Document, 0, k)
+	for i := 0; i < k; i++ {
+		result = append(result, scoredDocs[i].doc)
+	}
+	return result, nil
+}

--- a/internal/vectorstore/memstore_test.go
+++ b/internal/vectorstore/memstore_test.go
@@ -1,0 +1,19 @@
+package vectorstore
+
+import "testing"
+
+func TestMemoryStore(t *testing.T) {
+	store := NewMemoryStore()
+	SetDefaultStore(store)
+	doc := Document{ID: "1", Embedding: []float64{1, 0}, Metadata: map[string]interface{}{"text": "a"}}
+	if err := store.Upsert(nil, []Document{doc}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	results, err := store.Query(nil, []float64{1, 0}, 1)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != "1" {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+}

--- a/internal/vectorstore/vectorstore.go
+++ b/internal/vectorstore/vectorstore.go
@@ -1,0 +1,24 @@
+package vectorstore
+
+import "context"
+
+// Document represents an item stored in the vector store.
+type Document struct {
+	ID        string
+	Embedding []float64
+	Metadata  map[string]interface{}
+}
+
+// VectorStore defines the operations supported by a store.
+type VectorStore interface {
+	Upsert(ctx context.Context, docs []Document) error
+	Query(ctx context.Context, embedding []float64, k int) ([]Document, error)
+}
+
+var defaultStore VectorStore
+
+// SetDefaultStore configures the global store used by default.
+func SetDefaultStore(store VectorStore) { defaultStore = store }
+
+// DefaultStore returns the globally configured store.
+func DefaultStore() VectorStore { return defaultStore }


### PR DESCRIPTION
## Summary
- add in-memory vector store with interface for future DB integrations
- create embedding, retrieval, and rerank tools with simple logic
- expose new agents wrapping those tools
- document vector pipeline structure and next steps
- add unit tests for tools and vector store

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684dca29c4948323b7dc5426d6a9750f