### PR TITLE
Implement RAG generation pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ See [docs/architecture.md](docs/architecture.md) for a deeper architectural over
 - **Tool Interfaces** – Stubs for embedding, retrieval and reranking demonstrate how external capabilities plug in.
 - **HTTP Server Example** – `cmd/server` exposes pipeline execution through a simple API.
 - **Data Transform Agent** – Performs basic string manipulation operations.
+- **RAG Generation Pipeline** – Embedding, retrieval, context injection and generation agents ready for early testing.
 
 ## Example
 

--- a/docs/rag_generation.md
+++ b/docs/rag_generation.md
@@ -1,0 +1,35 @@
+# RAG Generation Pipeline
+
+This document outlines the current implementation for retrieval augmented generation (RAG).
+The goal is to expose a minimal yet production ready chain that can be used for
+early testing of end to end flows.
+
+## Overview
+
+1. **EmbeddingAgent** – Converts the user query into a vector using the configured
+   `EmbeddingProvider`.
+2. **RetrievalAgent** – Looks up similar documents from the `VectorStore`.
+3. **RerankAgent** – Orders the retrieved documents by relevance score.
+4. **PromptAgent** – Injects the retrieved context into a templated prompt.
+5. **GenerationAgent** – Sends the prompt to the Universal MCP endpoint and
+   returns the completion text.
+
+Each component runs as an agent so steps may execute concurrently where
+possible.  The `PromptAgent` and `GenerationAgent` are new additions that move
+the codebase beyond simple examples.
+
+## Remaining Work
+
+- **Real LLM integration** – the `GenerationAgent` currently posts to a
+  configurable HTTP endpoint.  Wiring this up to the chosen model provider and
+  handling authentication is required.
+- **Streaming responses** – the completion API currently returns the full text at
+  once.  Support for server-sent events or gRPC streaming will allow incremental
+  delivery to clients.
+- **Prompt templates from configuration** – templates are supplied in the task
+  input today.  Loading and versioning them from external files is planned.
+- **Observability and metrics** – structured logging of each step plus basic
+  metrics (latency, failure counts) are needed before production use.
+
+These tasks will harden the pipeline for real workloads while keeping the
+interfaces stable.

--- a/internal/agent/generation_agent.go
+++ b/internal/agent/generation_agent.go
@@ -1,0 +1,40 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"agentic.example.com/mvp/internal/tools"
+)
+
+// GenerationAgent calls a language model to generate a response from a prompt.
+type GenerationAgent struct {
+	id   string
+	tool *tools.CompletionTool
+}
+
+// NewGenerationAgent creates a GenerationAgent with the given completion endpoint.
+func NewGenerationAgent(endpoint string) *GenerationAgent {
+	return &GenerationAgent{
+		id:   fmt.Sprintf("generation-agent-%s", uuid.NewString()),
+		tool: tools.NewCompletionTool(endpoint),
+	}
+}
+
+func (g *GenerationAgent) ID() string { return g.id }
+
+// Execute expects input with key "prompt" and optional "model".
+// It forwards the request to the CompletionTool.
+func (g *GenerationAgent) Execute(ctx context.Context, task Task) Result {
+	out, err := g.tool.Run(ctx, task.Input)
+	if err != nil {
+		return Result{TaskID: task.ID, Error: err}
+	}
+	return Result{TaskID: task.ID, Output: out, Successful: true}
+}
+
+func init() {
+	Register("GenerationAgent", func() Agent { return NewGenerationAgent("http://localhost:8080/completion") })
+}

--- a/internal/agent/prompt_agent.go
+++ b/internal/agent/prompt_agent.go
@@ -1,0 +1,49 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"text/template"
+
+	"github.com/google/uuid"
+)
+
+// PromptAgent builds a prompt by applying a Go template to provided context.
+type PromptAgent struct {
+	id string
+}
+
+// NewPromptAgent creates a PromptAgent.
+func NewPromptAgent() *PromptAgent {
+	return &PromptAgent{id: fmt.Sprintf("prompt-agent-%s", uuid.NewString())}
+}
+
+func (p *PromptAgent) ID() string { return p.id }
+
+// Execute expects input with keys:
+//
+//	template: string - Go text/template string
+//	context:  map[string]interface{} - data for template execution
+//
+// Returns a map with key "prompt" containing the rendered template.
+func (p *PromptAgent) Execute(ctx context.Context, task Task) Result {
+	tmplStr, _ := task.Input["template"].(string)
+	if tmplStr == "" {
+		return Result{TaskID: task.ID, Error: fmt.Errorf("template required")}
+	}
+	data, _ := task.Input["context"].(map[string]interface{})
+	tmpl, err := template.New("prompt").Parse(tmplStr)
+	if err != nil {
+		return Result{TaskID: task.ID, Error: err}
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return Result{TaskID: task.ID, Error: err}
+	}
+	return Result{TaskID: task.ID, Output: map[string]interface{}{"prompt": buf.String()}, Successful: true}
+}
+
+func init() {
+	Register("PromptAgent", func() Agent { return NewPromptAgent() })
+}

--- a/internal/agent/prompt_agent_test.go
+++ b/internal/agent/prompt_agent_test.go
@@ -1,0 +1,15 @@
+package agent
+
+import "testing"
+
+func TestPromptAgent(t *testing.T) {
+	a := NewPromptAgent()
+	task := Task{ID: "1", Input: map[string]interface{}{
+		"template": "Hello {{.User}}",
+		"context":  map[string]interface{}{"User": "World"},
+	}}
+	res := a.Execute(nil, task)
+	if !res.Successful || res.Output.(map[string]interface{})["prompt"] != "Hello World" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+}

--- a/internal/tools/completion.go
+++ b/internal/tools/completion.go
@@ -1,0 +1,63 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+)
+
+// CompletionTool sends a prompt to a remote LLM endpoint and returns the completion text.
+// It is designed to work with the Universal MCP gateway.
+type CompletionTool struct {
+	Endpoint string
+	Client   *http.Client
+}
+
+// NewCompletionTool creates a CompletionTool for the given endpoint.
+func NewCompletionTool(endpoint string) *CompletionTool {
+	return &CompletionTool{
+		Endpoint: endpoint,
+		Client:   &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+func (c *CompletionTool) Run(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {
+	prompt, ok := input["prompt"].(string)
+	if !ok || prompt == "" {
+		return nil, errors.New("prompt required")
+	}
+	model, _ := input["model"].(string)
+	reqBody := map[string]interface{}{
+		"prompt": prompt,
+	}
+	if model != "" {
+		reqBody["model"] = model
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.Endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return nil, errors.New(resp.Status)
+	}
+	var out struct {
+		Completion string `json:"completion"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{"completion": out.Completion}, nil
+}

--- a/internal/tools/completion_test.go
+++ b/internal/tools/completion_test.go
@@ -1,0 +1,32 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCompletionTool(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var in map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if in["prompt"] != "hi" {
+			t.Fatalf("unexpected prompt: %v", in)
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{"completion": "hello"})
+	}))
+	defer srv.Close()
+
+	tool := NewCompletionTool(srv.URL)
+	out, err := tool.Run(context.Background(), map[string]interface{}{"prompt": "hi"})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out["completion"] != "hello" {
+		t.Fatalf("unexpected completion: %v", out)
+	}
+}


### PR DESCRIPTION
## Summary
- add completion tool for remote model calls
- create prompt and generation agents
- document RAG generation pipeline
- expose new pipeline in README
- basic unit tests for new components

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684de81201888323a5d058c18c878f40