### PR TITLE
Enhance vector pipeline utilities

### DIFF
--- a/docs/vector_pipeline.md
+++ b/docs/vector_pipeline.md
@@ -11,7 +11,9 @@ in-memory implementation for tests and a `QdrantStore` that talks to a remote
 Qdrant instance. The embedding step can be backed by a pluggable
 `EmbeddingProvider` so that local hashing can easily be replaced with a real
 model. Reranking likewise uses a pluggable `RerankProvider` which may call a
-remote cross-encoder service.
+remote cross-encoder service.  Stores and providers can now be initialised from
+environment configuration using `config.LoadFromEnv` together with
+`vectorstore.InitDefault` and `tools.InitDefaults`.
 
 ### Packages
 
@@ -29,16 +31,20 @@ remote cross-encoder service.
 
 ## Remaining Work
 
-1. **Authentication & TLS** – secure connections to the remote vector store and
-   embedding service. Basic API-key support is now implemented for Qdrant.
-2. **Advanced Reranking** – integrate a cross-encoder model to score documents
-   based on query relevance. A `RemoteRerankProvider` stub is available.
-3. **Pipeline Configuration** – load store URLs and embedding options from
-   environment variables via the new `config` package.
-4. **Observability** – structured logging and metrics around all vector
-   operations.
-5. **Deletion and Updates** – expose document deletion and partial updates for
-   completeness.
+The following items track what is still required before the vector pipeline can
+be considered production ready:
 
-These steps will take the foundation here to a live-ready state while keeping the
-API surface stable.
+1. **Authentication & TLS** – secure connections to the remote vector store and
+   remote providers. Qdrant API key support has landed but certificate
+   validation and token based auth need wiring up.
+2. **Advanced Reranking** – integrate a cross-encoder model to score documents
+   based on query relevance. The `RemoteRerankProvider` is a placeholder for this.
+3. **Observability** – add structured logging and Prometheus metrics around all
+   vector operations.
+4. **Dataset Management** – support bulk imports and incremental updates beyond
+   the simple upsert/delete calls now implemented.
+5. **Configuration Loader** – expose helper functions to read YAML/JSON configs
+   so environments can be provisioned without recompilation.
+
+Addressing these areas will harden the pipeline while keeping the API surface
+stable for early testing.

--- a/internal/tools/config.go
+++ b/internal/tools/config.go
@@ -1,0 +1,14 @@
+package tools
+
+import "agentic.example.com/mvp/internal/config"
+
+// InitDefaults configures global providers based on the given Config.
+// When endpoints are empty the built-in providers remain in use.
+func InitDefaults(cfg config.Config) {
+	if cfg.EmbeddingEndpoint != "" {
+		SetDefaultEmbeddingProvider(NewRemoteEmbeddingProvider(cfg.EmbeddingEndpoint))
+	}
+	if cfg.RerankEndpoint != "" {
+		SetDefaultRerankProvider(NewRemoteRerankProvider(cfg.RerankEndpoint))
+	}
+}

--- a/internal/vectorstore/config.go
+++ b/internal/vectorstore/config.go
@@ -1,0 +1,24 @@
+package vectorstore
+
+import "agentic.example.com/mvp/internal/config"
+
+// NewFromConfig creates a VectorStore based on the provided configuration.
+// If Endpoint is empty a MemoryStore is returned.
+func NewFromConfig(cfg config.VectorStoreConfig) VectorStore {
+	if cfg.Endpoint == "" {
+		return NewMemoryStore()
+	}
+	opts := []QdrantOption{}
+	if cfg.APIKey != "" {
+		opts = append(opts, WithAPIKey(cfg.APIKey))
+	}
+	if cfg.Insecure {
+		opts = append(opts, WithInsecureSkipVerify())
+	}
+	return NewQdrantStore(cfg.Endpoint, cfg.Collection, opts...)
+}
+
+// InitDefault sets the default global store using NewFromConfig.
+func InitDefault(cfg config.VectorStoreConfig) {
+	SetDefaultStore(NewFromConfig(cfg))
+}

--- a/internal/vectorstore/memstore.go
+++ b/internal/vectorstore/memstore.go
@@ -80,3 +80,21 @@ func (m *MemoryStore) Query(ctx context.Context, emb []float64, k int) ([]Docume
 	}
 	return result, nil
 }
+
+// Delete removes documents with the specified IDs.
+func (m *MemoryStore) Delete(ctx context.Context, ids []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	idSet := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		idSet[id] = struct{}{}
+	}
+	filtered := m.docs[:0]
+	for _, d := range m.docs {
+		if _, ok := idSet[d.ID]; !ok {
+			filtered = append(filtered, d)
+		}
+	}
+	m.docs = filtered
+	return nil
+}

--- a/internal/vectorstore/memstore_test.go
+++ b/internal/vectorstore/memstore_test.go
@@ -19,4 +19,15 @@ func TestMemoryStore(t *testing.T) {
 	if results[0].Score == 0 {
 		t.Fatalf("expected score to be set")
 	}
+
+	if err := store.Delete(nil, []string{"1"}); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	results, err = store.Query(nil, []float64{1, 0}, 1)
+	if err != nil {
+		t.Fatalf("query after delete: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected empty results after delete: %+v", results)
+	}
 }

--- a/internal/vectorstore/vectorstore.go
+++ b/internal/vectorstore/vectorstore.go
@@ -14,6 +14,7 @@ type Document struct {
 type VectorStore interface {
 	Upsert(ctx context.Context, docs []Document) error
 	Query(ctx context.Context, embedding []float64, k int) ([]Document, error)
+	Delete(ctx context.Context, ids []string) error
 }
 
 var defaultStore VectorStore


### PR DESCRIPTION
## Summary
- add Delete method to `VectorStore`
- implement delete support for memory and Qdrant stores
- allow vector store initialization from runtime config
- expose provider setup helper in tools package
- improve memory store test coverage
- update documentation for new features and outstanding work

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684decf72ed08323beed950fe2187eb8