### PR TITLE
Improve RAG pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Runtime options for connecting to external services are described in [docs/confi
 - **HTTP Server Example** – `cmd/server` exposes pipeline execution through a simple API.
 - **Data Transform Agent** – Performs basic string manipulation operations.
 - **RAG Generation Pipeline** – Embedding, retrieval, context injection and generation agents ready for early testing.
+- **Pipeline Builder** – `BuildRAGPipeline` returns a ready-to-run pipeline and
+  `ExtractRAGResponse` transforms raw results into a simple struct.
 
 ## Example
 

--- a/docs/rag_generation.md
+++ b/docs/rag_generation.md
@@ -14,6 +14,12 @@ early testing of end to end flows.
 5. **GenerationAgent** – Sends the prompt to the Universal MCP endpoint and
    returns the completion text.
 
+`internal/orchestrator.BuildRAGPipeline` wires these steps together. It expects
+initial input containing a user `query`, a prompt `template` and optionally a
+`model` name. After execution, `ExtractRAGResponse` converts the raw `StepData`
+into a simple `RAGResponse` struct holding the generated answer and the context
+documents.
+
 Each component runs as an agent so steps may execute concurrently where
 possible.  The `PromptAgent` and `GenerationAgent` are new additions that move
 the codebase beyond simple examples.
@@ -30,6 +36,10 @@ the codebase beyond simple examples.
   input today.  Loading and versioning them from external files is planned.
 - **Observability and metrics** – structured logging of each step plus basic
   metrics (latency, failure counts) are needed before production use.
+- **Advanced prompt management** – reference templates by name and version to
+  allow consistent updates across deployments.
+- **Better context filtering** – improved similarity scoring and heuristics will
+  ensure only the most relevant documents are injected into the prompt.
 
 These tasks will harden the pipeline for real workloads while keeping the
 interfaces stable.

--- a/internal/orchestrator/rag.go
+++ b/internal/orchestrator/rag.go
@@ -1,0 +1,109 @@
+package orchestrator
+
+import (
+	"agentic.example.com/mvp/internal/agent"
+)
+
+// BuildRAGPipeline returns a preconfigured retrieval augmented generation pipeline.
+// The pipeline expects initial input with keys:
+//
+//	query    - user query text
+//	template - prompt template string
+//	model    - optional model name for generation
+func BuildRAGPipeline(id string) Pipeline {
+	return Pipeline{
+		ID:          id,
+		Description: "retrieval augmented generation",
+		Groups: []PipelineGroup{
+			{
+				Name: "embed",
+				Steps: []PipelineStep{
+					{
+						Name:        "embed_query",
+						AgentType:   "EmbeddingAgent",
+						AgentConfig: agent.Task{Description: "Embed user query"},
+						InputMappings: map[string]string{
+							"text": "initial.query",
+						},
+					},
+				},
+			},
+			{
+				Name: "retrieve",
+				Steps: []PipelineStep{
+					{
+						Name:        "retrieve_docs",
+						AgentType:   "RetrievalAgent",
+						AgentConfig: agent.Task{Description: "Retrieve documents"},
+						InputMappings: map[string]string{
+							"embedding": "embed_query.default_output.embedding",
+						},
+					},
+				},
+			},
+			{
+				Name: "rerank",
+				Steps: []PipelineStep{
+					{
+						Name:        "rerank_docs",
+						AgentType:   "RerankAgent",
+						AgentConfig: agent.Task{Description: "Rerank documents"},
+						InputMappings: map[string]string{
+							"documents": "retrieve_docs.default_output.documents",
+							"query":     "initial.query",
+						},
+					},
+				},
+			},
+			{
+				Name: "prompt",
+				Steps: []PipelineStep{
+					{
+						Name:        "build_prompt",
+						AgentType:   "PromptAgent",
+						AgentConfig: agent.Task{Description: "Inject context"},
+						InputMappings: map[string]string{
+							"template": "initial.template",
+							"context":  "rerank_docs.default_output.reranked",
+						},
+					},
+				},
+			},
+			{
+				Name: "generate",
+				Steps: []PipelineStep{
+					{
+						Name:        "generate_answer",
+						AgentType:   "GenerationAgent",
+						AgentConfig: agent.Task{Description: "Generate final answer"},
+						InputMappings: map[string]string{
+							"prompt": "build_prompt.default_output.prompt",
+							"model":  "initial.model",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type RAGResponse struct {
+	Answer  string                   `json:"answer"`
+	Context []map[string]interface{} `json:"context"`
+}
+
+// ExtractRAGResponse builds a structured RAGResponse from StepData
+// returned by ExecutePipeline on a pipeline produced by BuildRAGPipeline.
+func ExtractRAGResponse(data StepData) (RAGResponse, bool) {
+	genOut, ok := data["generate_answer.default_output"].(map[string]interface{})
+	if !ok {
+		return RAGResponse{}, false
+	}
+	rerankOut, ok := data["rerank_docs.default_output"].(map[string]interface{})
+	if !ok {
+		return RAGResponse{}, false
+	}
+	answer, _ := genOut["completion"].(string)
+	ctx, _ := rerankOut["reranked"].([]map[string]interface{})
+	return RAGResponse{Answer: answer, Context: ctx}, true
+}

--- a/internal/orchestrator/rag_test.go
+++ b/internal/orchestrator/rag_test.go
@@ -1,0 +1,55 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"agentic.example.com/mvp/internal/tools"
+	"agentic.example.com/mvp/internal/vectorstore"
+)
+
+// TestResolveSourcePath ensures nested paths are resolved correctly.
+func TestResolveSourcePath(t *testing.T) {
+	data := StepData{"a.b": map[string]interface{}{"c": 1}}
+	val, ok := resolveSourcePath(data, "a.b.c")
+	if !ok || val.(int) != 1 {
+		t.Fatalf("unexpected result: %v %v", val, ok)
+	}
+}
+
+// TestRAGPipeline runs the RAG pipeline end-to-end with a local HTTP server.
+func TestRAGPipeline(t *testing.T) {
+	srv := &http.Server{Addr: ":8080"}
+	srv.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var in map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&in)
+		json.NewEncoder(w).Encode(map[string]string{"completion": "test"})
+	})
+	go srv.ListenAndServe()
+	defer srv.Shutdown(context.Background())
+
+	store := vectorstore.NewMemoryStore()
+	vectorstore.SetDefaultStore(store)
+	emb := tools.BasicHashEmbed("hello", 128)
+	store.Upsert(context.Background(), []vectorstore.Document{{ID: "1", Embedding: emb, Metadata: map[string]interface{}{"text": "hello"}}})
+
+	pipeline := BuildRAGPipeline("rag_test")
+	orc := NewOrchestrator()
+	input := map[string]interface{}{
+		"query":    "hello",
+		"template": "{{.context}}",
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	data, err := orc.ExecutePipeline(ctx, pipeline, input)
+	if err != nil {
+		t.Fatalf("pipeline error: %v", err)
+	}
+	resp, ok := ExtractRAGResponse(data)
+	if !ok || resp.Answer != "test" {
+		t.Fatalf("unexpected response: %#v", resp)
+	}
+}


### PR DESCRIPTION
## Summary
- add a builder for the retrieval augmented generation (RAG) pipeline
- provide a helper to extract a structured RAG response
- allow nested value lookups in orchestrator input mappings
- document the pipeline builder and remaining work

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ded2c89a083238be727206e5cb611