### PR TITLE
Enhance vector pipeline config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Runtime options for connecting to external services are described in [docs/confi
 - **Pipeline Orchestrator** – Executes ordered groups of steps.  Steps within a group run in their own goroutine and communicate results via channels.
 - **Tool Interfaces** – Stubs for embedding, retrieval and reranking demonstrate how external capabilities plug in.
 - **HTTP Server Example** – `cmd/server` exposes pipeline execution through a simple API.
+- **Configurable Retrieval** – `EMBEDDING_DIM` and `RETRIEVAL_TOP_K` environment
+  variables allow tuning default embedding size and number of documents
+  returned without recompiling.
 - **Data Transform Agent** – Performs basic string manipulation operations.
 - **RAG Generation Pipeline** – Embedding, retrieval, context injection and generation agents ready for early testing.
 - **Pipeline Builder** – `BuildRAGPipeline` returns a ready-to-run pipeline and

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -25,27 +25,8 @@ type executeResponse struct {
 func main() {
 	cfg := config.LoadFromEnv()
 
-	if cfg.VectorStore.Endpoint != "" && cfg.VectorStore.Collection != "" {
-		opts := []vectorstore.QdrantOption{}
-		if cfg.VectorStore.APIKey != "" {
-			opts = append(opts, vectorstore.WithAPIKey(cfg.VectorStore.APIKey))
-		}
-		if cfg.VectorStore.Insecure {
-			opts = append(opts, vectorstore.WithInsecureSkipVerify())
-		}
-		vectorstore.SetDefaultStore(
-			vectorstore.NewQdrantStore(cfg.VectorStore.Endpoint, cfg.VectorStore.Collection, opts...),
-		)
-	} else {
-		vectorstore.SetDefaultStore(vectorstore.NewMemoryStore())
-	}
-
-	if cfg.EmbeddingEndpoint != "" {
-		tools.SetDefaultEmbeddingProvider(tools.NewRemoteEmbeddingProvider(cfg.EmbeddingEndpoint))
-	}
-	if cfg.RerankEndpoint != "" {
-		tools.SetDefaultRerankProvider(tools.NewRemoteRerankProvider(cfg.RerankEndpoint))
-	}
+	vectorstore.InitDefault(cfg.VectorStore)
+	tools.InitDefaults(cfg)
 
 	orc := orchestrator.NewOrchestrator()
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,5 +10,7 @@ The vector pipeline relies on a few environment variables to configure remote se
 | `VECTORSTORE_INSECURE` | Set to `1` to skip TLS verification. |
 | `EMBEDDING_ENDPOINT` | HTTP endpoint for generating embeddings. |
 | `RERANK_ENDPOINT` | HTTP endpoint for reranking documents. |
+| `EMBEDDING_DIM` | Dimension for the built-in hash embedding provider. |
+| `RETRIEVAL_TOP_K` | Default number of documents to retrieve. |
 
 Applications can load these settings via `config.LoadFromEnv()` and use them to initialise the default tools and stores.

--- a/docs/vector_pipeline.md
+++ b/docs/vector_pipeline.md
@@ -15,6 +15,10 @@ remote cross-encoder service.  Stores and providers can now be initialised from
 environment configuration using `config.LoadFromEnv` together with
 `vectorstore.InitDefault` and `tools.InitDefaults`.
 
+The default hash embedding dimension and retrieval depth are also
+configurable through `EMBEDDING_DIM` and `RETRIEVAL_TOP_K`. These values
+allow tuning relevance without code changes.
+
 ### Packages
 
 * `internal/vectorstore` – Defines the `VectorStore` interface, `MemoryStore`
@@ -45,6 +49,13 @@ be considered production ready:
    the simple upsert/delete calls now implemented.
 5. **Configuration Loader** – expose helper functions to read YAML/JSON configs
    so environments can be provisioned without recompilation.
+6. **Production Configuration** – tune embedding dimension and retrieval depth
+   via `EMBEDDING_DIM` and `RETRIEVAL_TOP_K` environment variables. This allows
+   consistent behaviour across deployments.
+7. **Integration Tests** – add test suites exercising the Qdrant client and
+   remote rerank service using local containers.
+8. **Error Handling & Retry** – provide clearer error types and automatic
+   retries for transient failures.
 
 Addressing these areas will harden the pipeline while keeping the API surface
 stable for early testing.

--- a/internal/agent/retrieval_agent.go
+++ b/internal/agent/retrieval_agent.go
@@ -20,7 +20,7 @@ type RetrievalAgent struct {
 func NewRetrievalAgent() *RetrievalAgent {
 	return &RetrievalAgent{
 		id:   fmt.Sprintf("retrieval-agent-%s", uuid.NewString()),
-		tool: tools.NewRetrievalTool(vectorstore.DefaultStore(), 5),
+		tool: tools.NewRetrievalTool(vectorstore.DefaultStore(), tools.DefaultTopK()),
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"strconv"
 )
 
 // VectorStoreConfig holds configuration for connecting to a vector database.
@@ -17,6 +18,8 @@ type Config struct {
 	VectorStore       VectorStoreConfig
 	EmbeddingEndpoint string
 	RerankEndpoint    string
+	EmbeddingDim      int
+	RetrievalTopK     int
 }
 
 // LoadFromEnv builds a Config from environment variables.
@@ -26,6 +29,21 @@ func LoadFromEnv() Config {
 	if os.Getenv("VECTORSTORE_INSECURE") == "1" {
 		insecure = true
 	}
+
+	embDim := 0
+	if v := os.Getenv("EMBEDDING_DIM"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			embDim = n
+		}
+	}
+
+	topK := 0
+	if v := os.Getenv("RETRIEVAL_TOP_K"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			topK = n
+		}
+	}
+
 	return Config{
 		VectorStore: VectorStoreConfig{
 			Endpoint:   os.Getenv("VECTORSTORE_ENDPOINT"),
@@ -35,5 +53,7 @@ func LoadFromEnv() Config {
 		},
 		EmbeddingEndpoint: os.Getenv("EMBEDDING_ENDPOINT"),
 		RerankEndpoint:    os.Getenv("RERANK_ENDPOINT"),
+		EmbeddingDim:      embDim,
+		RetrievalTopK:     topK,
 	}
 }

--- a/internal/tools/config.go
+++ b/internal/tools/config.go
@@ -7,8 +7,15 @@ import "agentic.example.com/mvp/internal/config"
 func InitDefaults(cfg config.Config) {
 	if cfg.EmbeddingEndpoint != "" {
 		SetDefaultEmbeddingProvider(NewRemoteEmbeddingProvider(cfg.EmbeddingEndpoint))
+	} else if cfg.EmbeddingDim > 0 {
+		SetDefaultEmbeddingProvider(HashEmbeddingProvider{Dim: cfg.EmbeddingDim})
 	}
+
 	if cfg.RerankEndpoint != "" {
 		SetDefaultRerankProvider(NewRemoteRerankProvider(cfg.RerankEndpoint))
+	}
+
+	if cfg.RetrievalTopK > 0 {
+		SetDefaultTopK(cfg.RetrievalTopK)
 	}
 }

--- a/internal/tools/retrieval.go
+++ b/internal/tools/retrieval.go
@@ -16,10 +16,22 @@ type RetrievalTool struct {
 // NewRetrievalTool constructs a RetrievalTool.
 func NewRetrievalTool(store vectorstore.VectorStore, k int) *RetrievalTool {
 	if k <= 0 {
-		k = 5
+		k = DefaultTopK()
 	}
 	return &RetrievalTool{Store: store, TopK: k}
 }
+
+var defaultTopK = 5
+
+// SetDefaultTopK sets the global default for retrieval when none is provided.
+func SetDefaultTopK(k int) {
+	if k > 0 {
+		defaultTopK = k
+	}
+}
+
+// DefaultTopK returns the currently configured default top K.
+func DefaultTopK() int { return defaultTopK }
 
 // Run implements the Tool interface.
 func (r *RetrievalTool) Run(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {


### PR DESCRIPTION
## Summary
- add configuration knobs for embedding dimension and retrieval depth
- provide APIs to adjust retrieval defaults
- wire config initialization through `cmd/server`
- document new settings and expand future work items

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684df736e3548323a34384149ca48d12