### PR TITLE
Enhance RAG pipeline

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,5 +10,6 @@ The vector pipeline relies on a few environment variables to configure remote se
 | `VECTORSTORE_INSECURE` | Set to `1` to skip TLS verification. |
 | `EMBEDDING_ENDPOINT` | HTTP endpoint for generating embeddings. |
 | `RERANK_ENDPOINT` | HTTP endpoint for reranking documents. |
+| `COMPLETION_ENDPOINT` | HTTP endpoint for language model completion. |
 
 Applications can load these settings via `config.LoadFromEnv()` and use them to initialise the default tools and stores.

--- a/docs/rag_generation.md
+++ b/docs/rag_generation.md
@@ -16,24 +16,31 @@ early testing of end to end flows.
 
 `internal/orchestrator.BuildRAGPipeline` wires these steps together. It expects
 initial input containing a user `query`, a prompt `template` and optionally a
-`model` name. After execution, `ExtractRAGResponse` converts the raw `StepData`
-into a simple `RAGResponse` struct holding the generated answer and the context
-documents.
+`model` name. Additional optional fields include `top_k` to control how many
+documents are retrieved and `completion_endpoint` to override the generation
+service URL. After execution, `ExtractRAGResponse` converts the raw `StepData`
+into a `RAGResponse` struct that holds the generated answer and a list of
+`ContextDocument` values for the injected documents.
 
 Each component runs as an agent so steps may execute concurrently where
-possible.  The `PromptAgent` and `GenerationAgent` are new additions that move
-the codebase beyond simple examples.
+possible.  The `PromptAgent` and `GenerationAgent` now accept runtime options
+for the retrieval depth and completion endpoint allowing early integration tests
+against real services.
 
 ## Remaining Work
 
 - **Real LLM integration** – the `GenerationAgent` currently posts to a
-  configurable HTTP endpoint.  Wiring this up to the chosen model provider and
-  handling authentication is required.
+- **Real LLM integration** – the `GenerationAgent` can point to any HTTP
+  endpoint but proper authentication, error handling and retry logic still need
+  to be implemented.
 - **Streaming responses** – the completion API currently returns the full text at
   once.  Support for server-sent events or gRPC streaming will allow incremental
   delivery to clients.
 - **Prompt templates from configuration** – templates are supplied in the task
   input today.  Loading and versioning them from external files is planned.
+- **Central configuration** – environment variables or files should be used to
+  define default endpoints and retrieval parameters so deployments remain
+  consistent.
 - **Observability and metrics** – structured logging of each step plus basic
   metrics (latency, failure counts) are needed before production use.
 - **Advanced prompt management** – reference templates by name and version to

--- a/internal/agent/retrieval_agent.go
+++ b/internal/agent/retrieval_agent.go
@@ -24,6 +24,14 @@ func NewRetrievalAgent() *RetrievalAgent {
 	}
 }
 
+// NewRetrievalAgentWithK allows configuring the number of documents to return.
+func NewRetrievalAgentWithK(k int) *RetrievalAgent {
+	return &RetrievalAgent{
+		id:   fmt.Sprintf("retrieval-agent-%s", uuid.NewString()),
+		tool: tools.NewRetrievalTool(vectorstore.DefaultStore(), k),
+	}
+}
+
 func (r *RetrievalAgent) ID() string { return r.id }
 
 func (r *RetrievalAgent) Execute(ctx context.Context, task Task) Result {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,9 +14,10 @@ type VectorStoreConfig struct {
 
 // Config aggregates runtime settings for the pipeline tools.
 type Config struct {
-	VectorStore       VectorStoreConfig
-	EmbeddingEndpoint string
-	RerankEndpoint    string
+	VectorStore        VectorStoreConfig
+	EmbeddingEndpoint  string
+	RerankEndpoint     string
+	CompletionEndpoint string
 }
 
 // LoadFromEnv builds a Config from environment variables.
@@ -33,7 +34,8 @@ func LoadFromEnv() Config {
 			APIKey:     os.Getenv("VECTORSTORE_API_KEY"),
 			Insecure:   insecure,
 		},
-		EmbeddingEndpoint: os.Getenv("EMBEDDING_ENDPOINT"),
-		RerankEndpoint:    os.Getenv("RERANK_ENDPOINT"),
+		EmbeddingEndpoint:  os.Getenv("EMBEDDING_ENDPOINT"),
+		RerankEndpoint:     os.Getenv("RERANK_ENDPOINT"),
+		CompletionEndpoint: os.Getenv("COMPLETION_ENDPOINT"),
 	}
 }

--- a/internal/orchestrator/rag_test.go
+++ b/internal/orchestrator/rag_test.go
@@ -39,8 +39,9 @@ func TestRAGPipeline(t *testing.T) {
 	pipeline := BuildRAGPipeline("rag_test")
 	orc := NewOrchestrator()
 	input := map[string]interface{}{
-		"query":    "hello",
-		"template": "{{.context}}",
+		"query":               "hello",
+		"template":            "{{.context}}",
+		"completion_endpoint": "http://localhost:8080",
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -49,7 +50,7 @@ func TestRAGPipeline(t *testing.T) {
 		t.Fatalf("pipeline error: %v", err)
 	}
 	resp, ok := ExtractRAGResponse(data)
-	if !ok || resp.Answer != "test" {
+	if !ok || resp.Answer != "test" || len(resp.Documents) == 0 {
 		t.Fatalf("unexpected response: %#v", resp)
 	}
 }

--- a/internal/tools/completion.go
+++ b/internal/tools/completion.go
@@ -16,12 +16,25 @@ type CompletionTool struct {
 	Client   *http.Client
 }
 
+var defaultCompletionEndpoint = "http://localhost:8080/completion"
+
+// SetDefaultCompletionEndpoint defines the endpoint used when none is provided.
+func SetDefaultCompletionEndpoint(ep string) { defaultCompletionEndpoint = ep }
+
+// DefaultCompletionEndpoint returns the currently configured default endpoint.
+func DefaultCompletionEndpoint() string { return defaultCompletionEndpoint }
+
 // NewCompletionTool creates a CompletionTool for the given endpoint.
 func NewCompletionTool(endpoint string) *CompletionTool {
 	return &CompletionTool{
 		Endpoint: endpoint,
 		Client:   &http.Client{Timeout: 60 * time.Second},
 	}
+}
+
+// NewDefaultCompletionTool returns a tool using the configured default endpoint.
+func NewDefaultCompletionTool() *CompletionTool {
+	return NewCompletionTool(DefaultCompletionEndpoint())
 }
 
 func (c *CompletionTool) Run(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {

--- a/internal/tools/config.go
+++ b/internal/tools/config.go
@@ -11,4 +11,7 @@ func InitDefaults(cfg config.Config) {
 	if cfg.RerankEndpoint != "" {
 		SetDefaultRerankProvider(NewRemoteRerankProvider(cfg.RerankEndpoint))
 	}
+	if cfg.CompletionEndpoint != "" {
+		SetDefaultCompletionEndpoint(cfg.CompletionEndpoint)
+	}
 }

--- a/internal/tools/retrieval.go
+++ b/internal/tools/retrieval.go
@@ -27,6 +27,11 @@ func (r *RetrievalTool) Run(ctx context.Context, input map[string]interface{}) (
 	if !ok || len(emb) == 0 {
 		return nil, errors.New("embedding required")
 	}
+	if tk, ok := input["top_k"].(int); ok && tk > 0 {
+		r.TopK = tk
+	} else if tkf, ok := input["top_k"].(float64); ok && int(tkf) > 0 {
+		r.TopK = int(tkf)
+	}
 	if r.Store == nil {
 		r.Store = vectorstore.DefaultStore()
 	}


### PR DESCRIPTION
## Summary
- allow generation endpoint and retrieval top K to be configured at runtime
- include structured documents in RAG responses
- update RAG generation documentation and configuration docs
- expose completion endpoint via environment configuration
- adjust tests for new response format

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684df74384e883239adda7abbb21e23d