### PR TITLE
Improve RAG pipeline and context injection

### DIFF
--- a/docs/rag_generation.md
+++ b/docs/rag_generation.md
@@ -10,17 +10,19 @@ early testing of end to end flows.
    `EmbeddingProvider`.
 2. **RetrievalAgent** – Looks up similar documents from the `VectorStore`.
 3. **RerankAgent** – Orders the retrieved documents by relevance score.
-4. **PromptAgent** – Injects the retrieved context into a templated prompt.
+4. **PromptAgent** – Injects the retrieved documents, original query and any
+   extra context into a templated prompt.
 5. **GenerationAgent** – Sends the prompt to the Universal MCP endpoint and
    returns the completion text.
 
 `internal/orchestrator.BuildRAGPipeline` wires these steps together. It expects
 initial input containing a user `query`, a prompt `template` and optionally a
 `model` name. Additional optional fields include `top_k` to control how many
-documents are retrieved and `completion_endpoint` to override the generation
-service URL. After execution, `ExtractRAGResponse` converts the raw `StepData`
-into a `RAGResponse` struct that holds the generated answer and a list of
-`ContextDocument` values for the injected documents.
+documents are retrieved, `completion_endpoint` to override the generation
+service URL and `extra_context` to pass arbitrary data into the template.
+After execution, `ExtractRAGResponse` converts the raw `StepData` into a
+`RAGResponse` struct containing the original query, generated answer and the
+list of injected `ContextDocument` values.
 
 Each component runs as an agent so steps may execute concurrently where
 possible.  The `PromptAgent` and `GenerationAgent` now accept runtime options
@@ -29,18 +31,16 @@ against real services.
 
 ## Remaining Work
 
-- **Real LLM integration** – the `GenerationAgent` currently posts to a
 - **Real LLM integration** – the `GenerationAgent` can point to any HTTP
-  endpoint but proper authentication, error handling and retry logic still need
+  endpoint but proper authentication, retry logic and error handling still need
   to be implemented.
 - **Streaming responses** – the completion API currently returns the full text at
   once.  Support for server-sent events or gRPC streaming will allow incremental
   delivery to clients.
 - **Prompt templates from configuration** – templates are supplied in the task
-  input today.  Loading and versioning them from external files is planned.
-- **Central configuration** – environment variables or files should be used to
-  define default endpoints and retrieval parameters so deployments remain
-  consistent.
+  input today. Loading and versioning them from external files is planned.
+- **Central configuration** – environment variables or files should define
+  default endpoints and retrieval parameters so deployments remain consistent.
 - **Observability and metrics** – structured logging of each step plus basic
   metrics (latency, failure counts) are needed before production use.
 - **Advanced prompt management** – reference templates by name and version to

--- a/internal/agent/prompt_agent.go
+++ b/internal/agent/prompt_agent.go
@@ -9,30 +9,46 @@ import (
 	"github.com/google/uuid"
 )
 
-// PromptAgent builds a prompt by applying a Go template to provided context.
+// PromptAgent builds a prompt by applying a Go template to provided data.
+// It can merge arbitrary context with retrieved documents and the original query.
 type PromptAgent struct {
 	id string
 }
 
-// NewPromptAgent creates a PromptAgent.
+// NewPromptAgent creates a PromptAgent with a unique ID.
 func NewPromptAgent() *PromptAgent {
 	return &PromptAgent{id: fmt.Sprintf("prompt-agent-%s", uuid.NewString())}
 }
 
 func (p *PromptAgent) ID() string { return p.id }
 
-// Execute expects input with keys:
+// Execute expects input keys:
 //
-//	template: string - Go text/template string
-//	context:  map[string]interface{} - data for template execution
+//	template  - Go text/template string used to render the prompt
+//	documents - []map[string]interface{} representing retrieved context
+//	query     - optional original user query
+//	context   - optional additional map merged into the template data
 //
-// Returns a map with key "prompt" containing the rendered template.
+// The resulting prompt string is returned in the "prompt" field of the output map.
 func (p *PromptAgent) Execute(ctx context.Context, task Task) Result {
 	tmplStr, _ := task.Input["template"].(string)
 	if tmplStr == "" {
 		return Result{TaskID: task.ID, Error: fmt.Errorf("template required")}
 	}
-	data, _ := task.Input["context"].(map[string]interface{})
+
+	data := map[string]interface{}{}
+	if extra, ok := task.Input["context"].(map[string]interface{}); ok {
+		for k, v := range extra {
+			data[k] = v
+		}
+	}
+	if docs, ok := task.Input["documents"].([]map[string]interface{}); ok {
+		data["documents"] = docs
+	}
+	if q, ok := task.Input["query"].(string); ok {
+		data["query"] = q
+	}
+
 	tmpl, err := template.New("prompt").Parse(tmplStr)
 	if err != nil {
 		return Result{TaskID: task.ID, Error: err}
@@ -41,6 +57,7 @@ func (p *PromptAgent) Execute(ctx context.Context, task Task) Result {
 	if err := tmpl.Execute(&buf, data); err != nil {
 		return Result{TaskID: task.ID, Error: err}
 	}
+
 	return Result{TaskID: task.ID, Output: map[string]interface{}{"prompt": buf.String()}, Successful: true}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,11 +19,8 @@ type Config struct {
 	EmbeddingEndpoint  string
 	RerankEndpoint     string
 	CompletionEndpoint string
-	VectorStore       VectorStoreConfig
-	EmbeddingEndpoint string
-	RerankEndpoint    string
-	EmbeddingDim      int
-	RetrievalTopK     int
+	EmbeddingDim       int
+	RetrievalTopK      int
 }
 
 // LoadFromEnv builds a Config from environment variables.
@@ -58,9 +55,7 @@ func LoadFromEnv() Config {
 		EmbeddingEndpoint:  os.Getenv("EMBEDDING_ENDPOINT"),
 		RerankEndpoint:     os.Getenv("RERANK_ENDPOINT"),
 		CompletionEndpoint: os.Getenv("COMPLETION_ENDPOINT"),
-		EmbeddingEndpoint: os.Getenv("EMBEDDING_ENDPOINT"),
-		RerankEndpoint:    os.Getenv("RERANK_ENDPOINT"),
-		EmbeddingDim:      embDim,
-		RetrievalTopK:     topK,
+		EmbeddingDim:       embDim,
+		RetrievalTopK:      topK,
 	}
 }

--- a/internal/orchestrator/rag_test.go
+++ b/internal/orchestrator/rag_test.go
@@ -40,7 +40,7 @@ func TestRAGPipeline(t *testing.T) {
 	orc := NewOrchestrator()
 	input := map[string]interface{}{
 		"query":               "hello",
-		"template":            "{{.context}}",
+		"template":            "{{range .documents}}{{.metadata.text}}{{end}}",
 		"completion_endpoint": "http://localhost:8080",
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/internal/tools/config.go
+++ b/internal/tools/config.go
@@ -16,6 +16,7 @@ func InitDefaults(cfg config.Config) {
 	}
 	if cfg.CompletionEndpoint != "" {
 		SetDefaultCompletionEndpoint(cfg.CompletionEndpoint)
+	}
 	if cfg.RetrievalTopK > 0 {
 		SetDefaultTopK(cfg.RetrievalTopK)
 	}


### PR DESCRIPTION
## Summary
- add extra context input and query to prompt agent
- include query in RAGResponse
- update pipeline builder for new prompt inputs
- fix config struct and initialization logic
- update RAG generation documentation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e19fb05748323a639032980ee7efa