### PR TITLE
Improve vector pipeline with ingest tool and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Runtime options for connecting to external services are described in [docs/confi
   variables allow tuning default embedding size and number of documents
   returned without recompiling.
 - **Data Transform Agent** – Performs basic string manipulation operations.
+- **Ingest Agents and Tools** – Easily embed and store new documents in the
+  configured vector database.
 - **RAG Generation Pipeline** – Embedding, retrieval, context injection and generation agents ready for early testing.
 - **Pipeline Builder** – `BuildRAGPipeline` returns a ready-to-run pipeline and
   `ExtractRAGResponse` transforms raw results into a simple struct.

--- a/docs/vector_pipeline.md
+++ b/docs/vector_pipeline.md
@@ -28,10 +28,12 @@ allow tuning relevance without code changes.
     `RemoteEmbeddingProvider`, etc.).
   * `RetrievalTool` – queries a configured `VectorStore`.
   * `RerankTool` – orders documents using a `RerankProvider` when available.
+  * `IngestTool` – embeds text and stores it in the configured `VectorStore`.
 * `internal/agent` – Agents wrapping the tools so they can run as pipeline steps:
   * `EmbeddingAgent`
   * `RetrievalAgent`
   * `RerankAgent`
+  * `IngestAgent`
 
 ## Remaining Work
 
@@ -45,8 +47,9 @@ be considered production ready:
    based on query relevance. The `RemoteRerankProvider` is a placeholder for this.
 3. **Observability** – add structured logging and Prometheus metrics around all
    vector operations.
-4. **Dataset Management** – support bulk imports and incremental updates beyond
-   the simple upsert/delete calls now implemented.
+4. **Dataset Management** – the new `IngestTool` and `IngestAgent` provide a
+   simple path for adding documents, but bulk import and update workflows are
+   still needed.
 5. **Configuration Loader** – expose helper functions to read YAML/JSON configs
    so environments can be provisioned without recompilation.
 6. **Production Configuration** – tune embedding dimension and retrieval depth

--- a/internal/agent/ingest_agent.go
+++ b/internal/agent/ingest_agent.go
@@ -1,0 +1,38 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"agentic.example.com/mvp/internal/tools"
+)
+
+// IngestAgent embeds and stores documents in the configured vector store.
+type IngestAgent struct {
+	id   string
+	tool *tools.IngestTool
+}
+
+// NewIngestAgent creates an agent with default tool configuration.
+func NewIngestAgent() *IngestAgent {
+	return &IngestAgent{
+		id:   fmt.Sprintf("ingest-agent-%s", uuid.NewString()),
+		tool: tools.NewIngestTool(),
+	}
+}
+
+func (i *IngestAgent) ID() string { return i.id }
+
+func (i *IngestAgent) Execute(ctx context.Context, task Task) Result {
+	out, err := i.tool.Run(ctx, task.Input)
+	if err != nil {
+		return Result{TaskID: task.ID, Error: err}
+	}
+	return Result{TaskID: task.ID, Output: out, Successful: true}
+}
+
+func init() {
+	Register("IngestAgent", func() Agent { return NewIngestAgent() })
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,11 +19,8 @@ type Config struct {
 	EmbeddingEndpoint  string
 	RerankEndpoint     string
 	CompletionEndpoint string
-	VectorStore       VectorStoreConfig
-	EmbeddingEndpoint string
-	RerankEndpoint    string
-	EmbeddingDim      int
-	RetrievalTopK     int
+	EmbeddingDim       int
+	RetrievalTopK      int
 }
 
 // LoadFromEnv builds a Config from environment variables.
@@ -58,9 +55,7 @@ func LoadFromEnv() Config {
 		EmbeddingEndpoint:  os.Getenv("EMBEDDING_ENDPOINT"),
 		RerankEndpoint:     os.Getenv("RERANK_ENDPOINT"),
 		CompletionEndpoint: os.Getenv("COMPLETION_ENDPOINT"),
-		EmbeddingEndpoint: os.Getenv("EMBEDDING_ENDPOINT"),
-		RerankEndpoint:    os.Getenv("RERANK_ENDPOINT"),
-		EmbeddingDim:      embDim,
-		RetrievalTopK:     topK,
+		EmbeddingDim:       embDim,
+		RetrievalTopK:      topK,
 	}
 }

--- a/internal/tools/config.go
+++ b/internal/tools/config.go
@@ -16,6 +16,7 @@ func InitDefaults(cfg config.Config) {
 	}
 	if cfg.CompletionEndpoint != "" {
 		SetDefaultCompletionEndpoint(cfg.CompletionEndpoint)
+	}
 	if cfg.RetrievalTopK > 0 {
 		SetDefaultTopK(cfg.RetrievalTopK)
 	}

--- a/internal/tools/ingest.go
+++ b/internal/tools/ingest.go
@@ -1,0 +1,68 @@
+package tools
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+
+	"agentic.example.com/mvp/internal/vectorstore"
+)
+
+// IngestTool embeds text using an EmbeddingProvider and stores the resulting
+// vector in a VectorStore. It returns the document ID that was persisted.
+//
+// Expected input fields:
+//
+//	text     - string of content to embed
+//	id       - optional unique identifier for the document. If not provided a
+//	           uuid will be generated.
+//	metadata - optional map of additional payload values to store alongside the
+//	           vector.
+type IngestTool struct {
+	Store    vectorstore.VectorStore
+	Embedder *EmbeddingTool
+}
+
+// NewIngestTool constructs an IngestTool using default provider and store.
+func NewIngestTool() *IngestTool {
+	return &IngestTool{Embedder: &EmbeddingTool{}}
+}
+
+// Run implements the Tool interface.
+func (i *IngestTool) Run(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {
+	text, _ := input["text"].(string)
+	if text == "" {
+		return nil, errors.New("text field required")
+	}
+	id, _ := input["id"].(string)
+	metadata, _ := input["metadata"].(map[string]interface{})
+
+	if i.Embedder == nil {
+		i.Embedder = &EmbeddingTool{}
+	}
+	if i.Store == nil {
+		i.Store = vectorstore.DefaultStore()
+	}
+
+	out, err := i.Embedder.Run(ctx, map[string]interface{}{"text": text})
+	if err != nil {
+		return nil, err
+	}
+	emb := out["embedding"].([]float64)
+
+	doc := vectorstore.Document{ID: id, Embedding: emb, Metadata: metadata}
+	if doc.ID == "" {
+		doc.ID = generateID()
+	}
+	if err := i.Store.Upsert(ctx, []vectorstore.Document{doc}); err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{"id": doc.ID}, nil
+}
+
+// generateID returns a uuid string. Placed in a helper for testability.
+func generateID() string { return uuidNewString() }
+
+// uuidNewString is defined as a variable for patching in tests.
+var uuidNewString = func() string { return uuid.NewString() }

--- a/internal/tools/ingest_test.go
+++ b/internal/tools/ingest_test.go
@@ -1,0 +1,35 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"agentic.example.com/mvp/internal/vectorstore"
+)
+
+func TestIngestTool(t *testing.T) {
+	store := vectorstore.NewMemoryStore()
+	vectorstore.SetDefaultStore(store)
+
+	SetDefaultEmbeddingProvider(HashEmbeddingProvider{Dim: 8})
+
+	fixedID := "doc1"
+	uuidNewString = func() string { return fixedID }
+	defer func() { uuidNewString = uuid.NewString }()
+
+	tool := NewIngestTool()
+	out, err := tool.Run(context.Background(), map[string]interface{}{"text": "hello"})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out["id"] != fixedID {
+		t.Fatalf("unexpected id %v", out["id"])
+	}
+
+	docs, err := store.Query(context.Background(), BasicHashEmbed("hello", 8), 1)
+	if err != nil || len(docs) == 0 || docs[0].ID != fixedID {
+		t.Fatalf("document not stored: %v %v", err, docs)
+	}
+}


### PR DESCRIPTION
## Summary
- add IngestTool to embed text and store documents
- introduce IngestAgent wrapper
- fix config struct duplication
- expose configuration defaults via tools.InitDefaults
- document new ingestion capability and remaining work

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684e1a17958c8323908873d7e152e014