### PR TITLE
Enhance vector pipeline with filter and auth

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,8 @@ The vector pipeline relies on a few environment variables to configure remote se
 | `VECTORSTORE_INSECURE` | Set to `1` to skip TLS verification. |
 | `EMBEDDING_ENDPOINT` | HTTP endpoint for generating embeddings. |
 | `RERANK_ENDPOINT` | HTTP endpoint for reranking documents. |
+| `EMBEDDING_API_KEY` | Optional auth token for the embedding service. |
+| `RERANK_API_KEY` | Optional auth token for the rerank service. |
 | `COMPLETION_ENDPOINT` | HTTP endpoint for language model completion. |
 | `EMBEDDING_DIM` | Dimension for the built-in hash embedding provider. |
 | `RETRIEVAL_TOP_K` | Default number of documents to retrieve. |

--- a/docs/vector_pipeline.md
+++ b/docs/vector_pipeline.md
@@ -40,14 +40,23 @@ allow tuning relevance without code changes.
 The `QdrantStore` constructor accepts options for API keys, TLS behaviour and a
 custom `http.Client` so deployments can tune connection settings.
 
+### Recent Additions
+
+- `VectorStore.Query` now accepts a `QueryRequest` struct with optional
+  metadata `Filter` enabling server side filtering.
+- `RemoteEmbeddingProvider` and `RemoteRerankProvider` support custom HTTP
+  headers (e.g. API tokens) and use exponential backoff on retry.
+- Configuration variables `EMBEDDING_API_KEY` and `RERANK_API_KEY` pass these
+  tokens to the providers.
+
 ## Remaining Work
 
 These steps will take the foundation here to a live-ready state while keeping
 the API surface stable.
 
 1. **Authentication & TLS** – secure connections to the remote vector store and
-   embedding service. Qdrant API key support has landed but certificate
-   validation and token based auth need wiring up.
+   embedding/ rerank services. Basic API token support is in place but
+   certificate validation and OAuth flows still need wiring up.
 2. **Advanced Reranking** – integrate a cross-encoder model to score documents
    based on query relevance. The `RemoteRerankProvider` is a placeholder for
    this.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,9 +17,11 @@ type VectorStoreConfig struct {
 // Config aggregates runtime settings for the pipeline tools.
 // Values may be empty when the corresponding environment variables are unset.
 type Config struct {
-	VectorStore        VectorStoreConfig
-	EmbeddingEndpoint  string
-	RerankEndpoint     string
+	VectorStore       VectorStoreConfig
+	EmbeddingEndpoint string
+	EmbeddingAPIKey   string
+	RerankEndpoint    string
+	RerankAPIKey      string
 	// VectorStore defines connection details for the backing vector database.
 
 	// EmbeddingEndpoint optionally points to a remote service used for generating embeddings.
@@ -62,7 +64,9 @@ func LoadFromEnv() Config {
 			Insecure:   insecure,
 		},
 		EmbeddingEndpoint:  os.Getenv("EMBEDDING_ENDPOINT"),
+		EmbeddingAPIKey:    os.Getenv("EMBEDDING_API_KEY"),
 		RerankEndpoint:     os.Getenv("RERANK_ENDPOINT"),
+		RerankAPIKey:       os.Getenv("RERANK_API_KEY"),
 		CompletionEndpoint: os.Getenv("COMPLETION_ENDPOINT"),
 		EmbeddingDim:       embDim,
 		RetrievalTopK:      topK,

--- a/internal/tools/config.go
+++ b/internal/tools/config.go
@@ -6,13 +6,21 @@ import "agentic.example.com/mvp/internal/config"
 // When endpoints are empty the built-in providers remain in use.
 func InitDefaults(cfg config.Config) {
 	if cfg.EmbeddingEndpoint != "" {
-		SetDefaultEmbeddingProvider(NewRemoteEmbeddingProvider(cfg.EmbeddingEndpoint))
+		opts := []RemoteEmbedOption{}
+		if cfg.EmbeddingAPIKey != "" {
+			opts = append(opts, WithEmbedHeader("Authorization", cfg.EmbeddingAPIKey))
+		}
+		SetDefaultEmbeddingProvider(NewRemoteEmbeddingProvider(cfg.EmbeddingEndpoint, opts...))
 	} else if cfg.EmbeddingDim > 0 {
 		SetDefaultEmbeddingProvider(HashEmbeddingProvider{Dim: cfg.EmbeddingDim})
 	}
 
 	if cfg.RerankEndpoint != "" {
-		SetDefaultRerankProvider(NewRemoteRerankProvider(cfg.RerankEndpoint))
+		opts := []RemoteRerankOption{}
+		if cfg.RerankAPIKey != "" {
+			opts = append(opts, WithRerankHeader("Authorization", cfg.RerankAPIKey))
+		}
+		SetDefaultRerankProvider(NewRemoteRerankProvider(cfg.RerankEndpoint, opts...))
 	}
 	if cfg.CompletionEndpoint != "" {
 		SetDefaultCompletionEndpoint(cfg.CompletionEndpoint)

--- a/internal/tools/embedding_remote.go
+++ b/internal/tools/embedding_remote.go
@@ -18,15 +18,33 @@ type RemoteEmbeddingProvider struct {
 	// MaxRetries defines how many times a request should be retried on
 	// transport errors or non-2xx responses.
 	MaxRetries int
+	Headers    map[string]string
+}
+
+// RemoteEmbedOption customises a RemoteEmbeddingProvider.
+type RemoteEmbedOption func(*RemoteEmbeddingProvider)
+
+// WithEmbedHeader adds a custom HTTP header to requests.
+func WithEmbedHeader(k, v string) RemoteEmbedOption {
+	return func(r *RemoteEmbeddingProvider) {
+		if r.Headers == nil {
+			r.Headers = map[string]string{}
+		}
+		r.Headers[k] = v
+	}
 }
 
 // NewRemoteEmbeddingProvider constructs a provider targeting the given endpoint.
-func NewRemoteEmbeddingProvider(endpoint string) *RemoteEmbeddingProvider {
-	return &RemoteEmbeddingProvider{
+func NewRemoteEmbeddingProvider(endpoint string, opts ...RemoteEmbedOption) *RemoteEmbeddingProvider {
+	p := &RemoteEmbeddingProvider{
 		Endpoint:   endpoint,
 		Client:     &http.Client{Timeout: 30 * time.Second},
 		MaxRetries: 2,
 	}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
 }
 
 func (r *RemoteEmbeddingProvider) Embed(ctx context.Context, text string) ([]float64, error) {
@@ -42,6 +60,9 @@ func (r *RemoteEmbeddingProvider) Embed(ctx context.Context, text string) ([]flo
 			return nil, err
 		}
 		req.Header.Set("Content-Type", "application/json")
+		for k, v := range r.Headers {
+			req.Header.Set(k, v)
+		}
 
 		resp, err := r.Client.Do(req)
 		if err == nil && resp != nil && resp.StatusCode == http.StatusOK {
@@ -66,7 +87,8 @@ func (r *RemoteEmbeddingProvider) Embed(ctx context.Context, text string) ([]flo
 			}
 			return nil, fmt.Errorf("embedding request failed")
 		}
-		time.Sleep(time.Duration(attempt+1) * 100 * time.Millisecond)
+		backoff := time.Duration(100*(1<<attempt)) * time.Millisecond
+		time.Sleep(backoff)
 	}
 	return nil, fmt.Errorf("unreachable")
 }

--- a/internal/tools/ingest_test.go
+++ b/internal/tools/ingest_test.go
@@ -28,7 +28,7 @@ func TestIngestTool(t *testing.T) {
 		t.Fatalf("unexpected id %v", out["id"])
 	}
 
-	docs, err := store.Query(context.Background(), BasicHashEmbed("hello", 8), 1)
+        docs, err := store.Query(context.Background(), vectorstore.QueryRequest{Embedding: BasicHashEmbed("hello", 8), TopK: 1})
 	if err != nil || len(docs) == 0 || docs[0].ID != fixedID {
 		t.Fatalf("document not stored: %v %v", err, docs)
 	}

--- a/internal/tools/retrieval.go
+++ b/internal/tools/retrieval.go
@@ -47,7 +47,8 @@ func (r *RetrievalTool) Run(ctx context.Context, input map[string]interface{}) (
 	if r.Store == nil {
 		r.Store = vectorstore.DefaultStore()
 	}
-	docs, err := r.Store.Query(ctx, emb, r.TopK)
+	filter, _ := input["filter"].(map[string]interface{})
+	docs, err := r.Store.Query(ctx, vectorstore.QueryRequest{Embedding: emb, TopK: r.TopK, Filter: filter})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tools/retrieval_test.go
+++ b/internal/tools/retrieval_test.go
@@ -10,7 +10,7 @@ func TestRetrievalTool(t *testing.T) {
 	store := vectorstore.NewMemoryStore()
 	vectorstore.SetDefaultStore(store)
 	emb := BasicHashEmbed("hello", 8)
-	store.Upsert(nil, []vectorstore.Document{{ID: "1", Embedding: emb}})
+	store.Upsert(nil, []vectorstore.Document{{ID: "1", Embedding: emb, Metadata: map[string]interface{}{"tag": "x"}}})
 	tool := NewRetrievalTool(store, 1)
 	out, err := tool.Run(nil, map[string]interface{}{"embedding": emb})
 	if err != nil {
@@ -22,5 +22,18 @@ func TestRetrievalTool(t *testing.T) {
 	}
 	if _, ok := docs[0]["score"]; !ok {
 		t.Fatalf("missing score: %+v", docs[0])
+	}
+
+	out, err = tool.Run(nil, map[string]interface{}{"embedding": emb, "filter": map[string]interface{}{"tag": "x"}})
+	if err != nil || len(out["documents"].([]map[string]interface{})) != 1 {
+		t.Fatalf("filter not applied: %v %v", err, out)
+	}
+
+	out, err = tool.Run(nil, map[string]interface{}{"embedding": emb, "filter": map[string]interface{}{"tag": "y"}})
+	if err != nil {
+		t.Fatalf("run with filter: %v", err)
+	}
+	if len(out["documents"].([]map[string]interface{})) != 0 {
+		t.Fatalf("expected empty result with non matching filter")
 	}
 }

--- a/internal/vectorstore/memstore_test.go
+++ b/internal/vectorstore/memstore_test.go
@@ -9,7 +9,7 @@ func TestMemoryStore(t *testing.T) {
 	if err := store.Upsert(nil, []Document{doc}); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
-	results, err := store.Query(nil, []float64{1, 0}, 1)
+        results, err := store.Query(nil, QueryRequest{Embedding: []float64{1, 0}, TopK: 1})
 	if err != nil {
 		t.Fatalf("query: %v", err)
 	}
@@ -23,7 +23,7 @@ func TestMemoryStore(t *testing.T) {
 	if err := store.Delete(nil, []string{"1"}); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
-	results, err = store.Query(nil, []float64{1, 0}, 1)
+        results, err = store.Query(nil, QueryRequest{Embedding: []float64{1, 0}, TopK: 1})
 	if err != nil {
 		t.Fatalf("query after delete: %v", err)
 	}

--- a/internal/vectorstore/vectorstore.go
+++ b/internal/vectorstore/vectorstore.go
@@ -10,10 +10,17 @@ type Document struct {
 	Score     float64 // optional score returned by queries
 }
 
+// QueryRequest describes a retrieval operation.
+type QueryRequest struct {
+	Embedding []float64
+	TopK      int
+	Filter    map[string]interface{}
+}
+
 // VectorStore defines the operations supported by a store.
 type VectorStore interface {
 	Upsert(ctx context.Context, docs []Document) error
-	Query(ctx context.Context, embedding []float64, k int) ([]Document, error)
+	Query(ctx context.Context, req QueryRequest) ([]Document, error)
 	Delete(ctx context.Context, ids []string) error
 }
 


### PR DESCRIPTION
## Summary
- support metadata filters with QueryRequest
- add authentication headers and backoff for remote providers
- surface embedding and rerank API keys via config
- document new env vars and capabilities
- update tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e4321d19c83238916aea6547e0a1d