### PR TITLE
Enhance RAG pipeline with context builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Runtime options for connecting to external services are described in [docs/confi
 - **Data Transform Agent** – Performs basic string manipulation operations.
 - **Ingest Agents and Tools** – Easily embed and store new documents in the
   configured vector database.
-- **RAG Generation Pipeline** – Embedding, retrieval, context injection and generation agents ready for early testing.
+- **RAG Generation Pipeline** – Embedding, retrieval, context formatting and generation agents ready for early testing.
 - **Pipeline Builder** – `BuildRAGPipeline` constructs a ready-to-run pipeline with optional defaults, and
   `ExtractRAGResponse` transforms raw results into a structured `RAGResponse`.
 

--- a/docs/rag_generation.md
+++ b/docs/rag_generation.md
@@ -10,11 +10,13 @@ early testing of end to end flows.
    `EmbeddingProvider`.
 2. **RetrievalAgent** – Looks up similar documents from the `VectorStore`.
 3. **RerankAgent** – Orders the retrieved documents by relevance score.
-4. **PromptAgent** – Injects the retrieved documents, original query and any
-   extra context into a templated prompt.
-5. **GenerationAgent** – Sends the prompt to the Universal MCP endpoint and
+4. **ContextBuilderAgent** – Collates the reranked documents and optional extra
+   context into a formatted string ready for prompting.
+5. **PromptAgent** – Injects the retrieved documents, original query and
+   formatted context into a templated prompt.
+6. **GenerationAgent** – Sends the prompt to the Universal MCP endpoint and
    returns the completion text.
-6. **Reasoning Step (optional)** – When enabled, the pipeline builds a second
+7. **Reasoning Step (optional)** – When enabled, the pipeline builds a second
    prompt containing the first answer and source context. Another
    `GenerationAgent` call produces a natural language explanation which is
    returned as part of the `RAGResponse`.
@@ -27,7 +29,8 @@ generation endpoint. The initial input must include a user `query` and a prompt
 `RAGPipelineOptions`, the `reason_template` is used to craft a second prompt for
 explanations. After execution, `ExtractRAGResponse` converts the raw
 `StepData` into a `RAGResponse` struct containing the original query, generated
-answer, reasoning text and the list of injected `ContextDocument` values.
+answer, the formatted context string, reasoning text and the list of injected
+`ContextDocument` values.
 
 Each component runs as an agent so steps may execute concurrently where
 possible.  The `PromptAgent` and `GenerationAgent` now accept runtime options

--- a/internal/agent/context_builder_agent.go
+++ b/internal/agent/context_builder_agent.go
@@ -1,0 +1,85 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// ContextBuilderAgent converts retrieved documents into a string of context
+// that can be injected into downstream prompts. It joins the selected field
+// from each document using the provided separator and merges any extra context
+// values into the output map.
+type ContextBuilderAgent struct {
+	id string
+}
+
+// NewContextBuilderAgent creates a ContextBuilderAgent with a unique ID.
+func NewContextBuilderAgent() *ContextBuilderAgent {
+	return &ContextBuilderAgent{id: fmt.Sprintf("ctx-builder-%s", uuid.NewString())}
+}
+
+func (c *ContextBuilderAgent) ID() string { return c.id }
+
+func getNested(m map[string]interface{}, path string) (interface{}, bool) {
+	parts := strings.Split(path, ".")
+	cur := interface{}(m)
+	for _, p := range parts {
+		mp, ok := cur.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		cur, ok = mp[p]
+		if !ok {
+			return nil, false
+		}
+	}
+	return cur, true
+}
+
+// Execute expects input keys:
+//
+//	documents - slice of document maps from retrieval
+//	field     - optional dotted path within each document to extract (defaults to "metadata.text")
+//	separator - optional join string used between documents (defaults to "\n")
+//	extra     - optional map merged into the output context
+//
+// The output is a map[string]interface{} that can be provided directly to PromptAgent
+// under its "context" input.
+func (c *ContextBuilderAgent) Execute(ctx context.Context, task Task) Result {
+	docs, ok := task.Input["documents"].([]map[string]interface{})
+	if !ok {
+		return Result{TaskID: task.ID, Error: fmt.Errorf("documents required")}
+	}
+	field, _ := task.Input["field"].(string)
+	if field == "" {
+		field = "metadata.text"
+	}
+	sep, _ := task.Input["separator"].(string)
+	if sep == "" {
+		sep = "\n"
+	}
+
+	var parts []string
+	for _, d := range docs {
+		if val, ok := getNested(d, field); ok {
+			if s, ok := val.(string); ok && s != "" {
+				parts = append(parts, s)
+			}
+		}
+	}
+	combined := strings.Join(parts, sep)
+	contextMap := map[string]interface{}{"retrieved_context": combined}
+	if extra, ok := task.Input["extra"].(map[string]interface{}); ok {
+		for k, v := range extra {
+			contextMap[k] = v
+		}
+	}
+	return Result{TaskID: task.ID, Output: contextMap, Successful: true}
+}
+
+func init() {
+	Register("ContextBuilderAgent", func() Agent { return NewContextBuilderAgent() })
+}

--- a/internal/orchestrator/rag.go
+++ b/internal/orchestrator/rag.go
@@ -73,6 +73,20 @@ func BuildRAGPipeline(id string, opts RAGPipelineOptions) Pipeline {
 			},
 		},
 		{
+			Name: "context",
+			Steps: []PipelineStep{
+				{
+					Name:        "build_context",
+					AgentType:   "ContextBuilderAgent",
+					AgentConfig: agent.Task{Description: "Format retrieved context"},
+					InputMappings: map[string]string{
+						"documents": "rerank_docs.default_output.reranked",
+						"extra":     "initial.extra_context",
+					},
+				},
+			},
+		},
+		{
 			Name: "prompt",
 			Steps: []PipelineStep{
 				{
@@ -83,7 +97,7 @@ func BuildRAGPipeline(id string, opts RAGPipelineOptions) Pipeline {
 						"template":  "initial.template",
 						"documents": "rerank_docs.default_output.reranked",
 						"query":     "initial.query",
-						"context":   "initial.extra_context",
+						"context":   "build_context.default_output",
 					},
 				},
 			},
@@ -121,7 +135,7 @@ func BuildRAGPipeline(id string, opts RAGPipelineOptions) Pipeline {
 						"documents": "rerank_docs.default_output.reranked",
 						"query":     "initial.query",
 						"answer":    "generate_answer.default_output.completion",
-						"context":   "initial.extra_context",
+						"context":   "build_context.default_output",
 					},
 				},
 				{
@@ -162,6 +176,7 @@ type RAGResponse struct {
 	Documents []ContextDocument `json:"documents"`
 	Model     string            `json:"model,omitempty"`
 	Prompt    string            `json:"prompt,omitempty"`
+	Context   string            `json:"context,omitempty"`
 	Reasoning string            `json:"reasoning,omitempty"`
 }
 
@@ -178,6 +193,8 @@ func ExtractRAGResponse(data StepData) (RAGResponse, bool) {
 	}
 	answer, _ := genOut["completion"].(string)
 	prompt, _ := data["build_prompt.default_output"].(map[string]interface{})
+	ctxMap, _ := data["build_context.default_output"].(map[string]interface{})
+	formattedCtx, _ := ctxMap["retrieved_context"].(string)
 	query, _ := data["initial.query"].(string)
 	model, _ := data["initial.model"].(string)
 	ctx, _ := rerankOut["reranked"].([]map[string]interface{})
@@ -200,5 +217,5 @@ func ExtractRAGResponse(data StepData) (RAGResponse, bool) {
 	if prompt != nil {
 		pr, _ = prompt["prompt"].(string)
 	}
-	return RAGResponse{Query: query, Answer: answer, Documents: docs, Model: model, Prompt: pr, Reasoning: reasoning}, true
+	return RAGResponse{Query: query, Answer: answer, Documents: docs, Model: model, Prompt: pr, Context: formattedCtx, Reasoning: reasoning}, true
 }

--- a/internal/orchestrator/rag_test.go
+++ b/internal/orchestrator/rag_test.go
@@ -40,7 +40,7 @@ func TestRAGPipeline(t *testing.T) {
 	orc := NewOrchestrator()
 	input := map[string]interface{}{
 		"query":               "hello",
-		"template":            "{{range .documents}}{{.metadata.text}}{{end}}",
+		"template":            "{{.retrieved_context}}",
 		"completion_endpoint": "http://localhost:8080",
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -50,7 +50,7 @@ func TestRAGPipeline(t *testing.T) {
 		t.Fatalf("pipeline error: %v", err)
 	}
 	resp, ok := ExtractRAGResponse(data)
-	if !ok || resp.Answer != "test" || len(resp.Documents) == 0 {
+	if !ok || resp.Answer != "test" || len(resp.Documents) == 0 || resp.Context != "hello\nhello" {
 		t.Fatalf("unexpected response: %#v", resp)
 	}
 }


### PR DESCRIPTION
## Summary
- implement new `ContextBuilderAgent` to consolidate retrieved documents
- add new `context` group to `BuildRAGPipeline`
- return formatted context in `RAGResponse`
- update docs and README for revised pipeline
- expand unit tests for updated pipeline

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684e74b2a7e0832390b4c00065df1c48