### PR TITLE
Implement planning agent flow

### DIFF
--- a/docs/flow_patterns_implementation.md
+++ b/docs/flow_patterns_implementation.md
@@ -92,3 +92,16 @@ This sequential group model is a solid foundation but does not yet cover dynamic
 - Extend the pipeline definition schema (YAML/JSON) to express branching rules, retries and streaming indicators.
 
 These additions will gradually evolve the existing pipeline into a more autonomous system that can adapt to real‑world scenarios while staying compatible with the current orchestration core.
+
+## Progress Update (2025-06-16)
+
+The repository now contains initial implementations for several of the patterns listed above:
+
+- **Event Driven Pipelines**: a `watcher` package provides a `TickerWatcher` and
+  `Orchestrator.StartWatcher` starts pipelines when events arrive.
+- **Planner–Executor Loop**: a `SimplePlanningAgent` generates pipeline step
+  definitions from a goal. `Orchestrator.ExecutePlanningPipeline` converts the
+  plan to a pipeline and executes it.
+
+These prototypes offer a foundation for more advanced flows such as critic
+feedback and dynamic branching in the future.

--- a/internal/agent/planning_agent.go
+++ b/internal/agent/planning_agent.go
@@ -1,0 +1,67 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"github.com/google/uuid"
+)
+
+// PlannedStep mirrors the orchestrator PipelineStep structure but lives in the
+// agent package to avoid import cycles.
+type PlannedStep struct {
+	Name          string
+	AgentType     string
+	AgentConfig   Task
+	InputMappings map[string]string
+	BranchKey     string
+}
+
+// PlanningAgent is an agent that converts a high level goal into a slice of
+// planned steps which can later be converted to a pipeline definition.
+type PlanningAgent interface {
+	Agent
+	Plan(goal string) ([]PlannedStep, error)
+}
+
+// SimplePlanningAgent is a trivial implementation used for examples and tests.
+// It generates a single EchoAgent step that echoes the provided goal.
+type SimplePlanningAgent struct {
+	agentID string
+}
+
+func NewSimplePlanningAgent() *SimplePlanningAgent {
+	return &SimplePlanningAgent{agentID: fmt.Sprintf("planner-%s", uuid.NewString())}
+}
+
+func (p *SimplePlanningAgent) ID() string { return p.agentID }
+
+func (p *SimplePlanningAgent) Plan(goal string) ([]PlannedStep, error) {
+	step := PlannedStep{
+		Name:      "echo_goal",
+		AgentType: "EchoAgent",
+		AgentConfig: Task{
+			Description: "echo planned goal",
+			Input:       map[string]interface{}{"message": goal},
+		},
+		InputMappings: map[string]string{},
+	}
+	return []PlannedStep{step}, nil
+}
+
+// Execute satisfies the Agent interface. It expects the task input to contain a
+// "goal" string and returns the planned steps as the result output.
+func (p *SimplePlanningAgent) Execute(ctx context.Context, task Task) Result {
+	goal, ok := task.Input["goal"].(string)
+	if !ok {
+		return Result{TaskID: task.ID, Error: fmt.Errorf("missing goal"), Successful: false}
+	}
+	steps, err := p.Plan(goal)
+	if err != nil {
+		return Result{TaskID: task.ID, Error: err, Successful: false}
+	}
+	return Result{TaskID: task.ID, Output: steps, Successful: true}
+}
+
+func init() {
+	Register("SimplePlanningAgent", func() Agent { return NewSimplePlanningAgent() })
+}

--- a/internal/orchestrator/planner.go
+++ b/internal/orchestrator/planner.go
@@ -1,0 +1,45 @@
+package orchestrator
+
+import (
+	"agentic.example.com/mvp/internal/agent"
+	"context"
+	"fmt"
+	"github.com/google/uuid"
+)
+
+// ExecutePlanningPipeline obtains a plan from the provided PlanningAgent using
+// the goal string and then executes the resulting pipeline. The planner output
+// is converted into a single pipeline group.
+func (o *Orchestrator) ExecutePlanningPipeline(ctx context.Context, planner agent.PlanningAgent, goal string) (StepData, error) {
+	planRes := planner.Execute(ctx, agent.Task{
+		ID:          fmt.Sprintf("plan-%s", uuid.NewString()),
+		Description: "generate pipeline plan",
+		Input:       map[string]interface{}{"goal": goal},
+	})
+	if !planRes.Successful {
+		return nil, fmt.Errorf("planning failed: %w", planRes.Error)
+	}
+
+	steps, ok := planRes.Output.([]agent.PlannedStep)
+	if !ok {
+		return nil, fmt.Errorf("planner returned unexpected output")
+	}
+
+	pipelineSteps := make([]PipelineStep, len(steps))
+	for i, st := range steps {
+		pipelineSteps[i] = PipelineStep{
+			Name:          st.Name,
+			AgentType:     st.AgentType,
+			AgentConfig:   st.AgentConfig,
+			InputMappings: st.InputMappings,
+			BranchKey:     st.BranchKey,
+		}
+	}
+
+	p := Pipeline{
+		ID:     fmt.Sprintf("dynamic-%s", uuid.NewString()),
+		Groups: []PipelineGroup{{Name: "generated", Steps: pipelineSteps}},
+	}
+
+	return o.ExecutePipeline(ctx, p, nil)
+}


### PR DESCRIPTION
## Summary
- add SimplePlanningAgent and planning interfaces
- execute planner output as a generated pipeline
- document newly implemented patterns

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685077db8c588323b0ade63c349550bc