### PR TITLE
Implement critic feedback flow

### DIFF
--- a/docs/flow_patterns_implementation.md
+++ b/docs/flow_patterns_implementation.md
@@ -105,3 +105,15 @@ The repository now contains initial implementations for several of the patterns 
 
 These prototypes offer a foundation for more advanced flows such as critic
 feedback and dynamic branching in the future.
+
+## Progress Update (2025-06-17)
+
+The code base now supports the **Critic Feedback Flow**:
+
+- `PipelineStep` accepts optional `CriticType`, `CriticConfig` and
+  `MaxRetries` fields.
+- A new `KeywordCriticAgent` demonstrates the `CriticAgent` interface. It
+  reviews worker output and may request a retry with adjusted input.
+- `Orchestrator.RunPipeline` loops when the critic requests a retry, up to the
+  configured `MaxRetries`.
+- Unit test `TestCriticRetry` covers a simple retry scenario.

--- a/internal/agent/critic_agent.go
+++ b/internal/agent/critic_agent.go
@@ -1,0 +1,79 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// CriticResult captures the outcome of a critic review.
+type CriticResult struct {
+	Approved      bool
+	Retry         bool
+	AdjustedInput map[string]interface{}
+	Escalate      bool
+}
+
+// CriticAgent reviews the output of another agent.
+type CriticAgent interface {
+	Review(ctx context.Context, result Result) CriticResult
+}
+
+// KeywordCriticAgent requests a retry when the worker output contains a
+// forbidden word. It optionally suggests a replacement text for the retry.
+type KeywordCriticAgent struct {
+	id         string
+	RejectWord string
+	Suggest    string
+}
+
+// NewKeywordCriticAgent creates a critic that rejects the given word.
+func NewKeywordCriticAgent(reject, suggest string) *KeywordCriticAgent {
+	return &KeywordCriticAgent{
+		id:         fmt.Sprintf("critic-%s", uuid.NewString()),
+		RejectWord: reject,
+		Suggest:    suggest,
+	}
+}
+
+func (k *KeywordCriticAgent) ID() string { return k.id }
+
+// Execute satisfies the Agent interface for compatibility with the registry.
+// The task input must include a `result` field containing the worker Result.
+func (k *KeywordCriticAgent) Execute(ctx context.Context, task Task) Result {
+	res, ok := task.Input["result"].(Result)
+	if !ok {
+		return Result{TaskID: task.ID, Error: fmt.Errorf("missing result")}
+	}
+	fb := k.Review(ctx, res)
+	return Result{TaskID: task.ID, Output: fb, Successful: true}
+}
+
+// Review implements the CriticAgent interface.
+func (k *KeywordCriticAgent) Review(ctx context.Context, res Result) CriticResult {
+	var text string
+	if m, ok := res.Output.(map[string]interface{}); ok {
+		if s, ok := m["output"].(string); ok {
+			text = s
+		} else if s, ok := m["message"].(string); ok {
+			text = s
+		}
+	} else if s, ok := res.Output.(string); ok {
+		text = s
+	}
+
+	if strings.Contains(strings.ToLower(text), strings.ToLower(k.RejectWord)) {
+		fb := CriticResult{Approved: false, Retry: true}
+		if k.Suggest != "" {
+			fb.AdjustedInput = map[string]interface{}{"text": k.Suggest}
+		}
+		return fb
+	}
+	return CriticResult{Approved: true}
+}
+
+func init() {
+	Register("KeywordCriticAgent", func() Agent { return NewKeywordCriticAgent("bad", "good") })
+}

--- a/internal/orchestrator/critic_test.go
+++ b/internal/orchestrator/critic_test.go
@@ -1,0 +1,49 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"agentic.example.com/mvp/internal/agent"
+)
+
+type textAgent struct{ text string }
+
+func (t *textAgent) ID() string { return "text-agent" }
+func (t *textAgent) Execute(ctx context.Context, task agent.Task) agent.Result {
+	out := t.text
+	if val, ok := task.Input["text"].(string); ok {
+		out = val
+	}
+	return agent.Result{TaskID: task.ID, Output: map[string]interface{}{"output": out}, Successful: true}
+}
+
+func init() {
+	agent.Register("TextAgent", func() agent.Agent { return &textAgent{text: "bad"} })
+}
+
+func TestCriticRetry(t *testing.T) {
+	p := Pipeline{
+		ID: "critic",
+		Groups: []PipelineGroup{{
+			Name: "work",
+			Steps: []PipelineStep{{
+				Name:        "emit",
+				AgentType:   "TextAgent",
+				CriticType:  "KeywordCriticAgent",
+				MaxRetries:  1,
+				AgentConfig: agent.Task{Description: "emit"},
+			}},
+		}},
+	}
+
+	orc := NewOrchestrator()
+	data, err := orc.ExecutePipeline(context.Background(), p, nil)
+	if err != nil {
+		t.Fatalf("pipeline error: %v", err)
+	}
+	out, _ := data["emit.default_output"].(map[string]interface{})
+	if out["output"] != "good" {
+		t.Fatalf("expected retry to adjust output to 'good', got %#v", out)
+	}
+}

--- a/internal/orchestrator/pipeline.go
+++ b/internal/orchestrator/pipeline.go
@@ -27,7 +27,10 @@ type PipelineStep struct {
 	// BranchKey, when set, specifies the result field containing a branch
 	// label. The orchestrator uses this label to select the next pipeline
 	// group.
-	BranchKey string
+	BranchKey    string
+	CriticType   string     // Optional critic agent for feedback
+	CriticConfig agent.Task // Base task for the critic agent
+	MaxRetries   int        // Number of times to retry on critic request
 }
 
 // Pipeline defines a sequence of steps executed by the orchestrator.


### PR DESCRIPTION
## Summary
- support per-step critic agents with retries
- implement `KeywordCriticAgent` as example critic
- add retry logic in orchestrator when a critic rejects
- document progress update
- add test covering critic retry

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685078fc62788323b058be7bc5ce4861