### PR TITLE
Implement checkpoint resume feature

### DIFF
--- a/docs/flow_patterns_implementation.md
+++ b/docs/flow_patterns_implementation.md
@@ -127,3 +127,13 @@ Initial support for the **Collaborative Multi-Agent Workspace** has been added:
 - Pipeline test `TestWorkspaceSharing` demonstrates agents sharing data across groups.
 
 These pieces pave the way for more sophisticated collaboration patterns in future iterations.
+
+## Progress Update (2025-06-19)
+
+A basic implementation of the **Checkpoint and Resume** pattern is now available:
+
+- New `CheckpointManager` persists pipeline state to JSON files.
+- `Orchestrator.ExecutePipelineWithCheckpoint` loads and saves progress after each group.
+- Unit test `TestCheckpointResume` verifies that a pipeline can resume after a partial run and removes the checkpoint on success.
+
+This groundwork will allow long running pipelines to survive interruptions and continue where they left off.

--- a/internal/orchestrator/checkpoint.go
+++ b/internal/orchestrator/checkpoint.go
@@ -1,0 +1,75 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// CheckpointManager persists pipeline progress to disk so that execution can
+// resume after interruptions.
+type CheckpointManager struct {
+	Dir string
+}
+
+type checkpointFile struct {
+	GroupIndex int      `json:"group_index"`
+	Data       StepData `json:"data"`
+}
+
+// NewCheckpointManager returns a manager storing files in the given directory.
+func NewCheckpointManager(dir string) *CheckpointManager {
+	return &CheckpointManager{Dir: dir}
+}
+
+func (m *CheckpointManager) filePath(id string) string {
+	return filepath.Join(m.Dir, fmt.Sprintf("%s.json", id))
+}
+
+// Save writes the current pipeline state to disk.
+func (m *CheckpointManager) Save(id string, index int, data StepData) error {
+	if m == nil {
+		return nil
+	}
+	cp := checkpointFile{GroupIndex: index, Data: data}
+	b, err := json.Marshal(cp)
+	if err != nil {
+		return err
+	}
+	path := m.filePath(id)
+	if err := os.WriteFile(path, b, 0644); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Load retrieves a previously saved checkpoint. If none exists, index will be 0
+// and data nil.
+func (m *CheckpointManager) Load(id string) (int, StepData, error) {
+	if m == nil {
+		return 0, nil, os.ErrNotExist
+	}
+	path := m.filePath(id)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return 0, nil, err
+	}
+	var cp checkpointFile
+	if err := json.Unmarshal(b, &cp); err != nil {
+		return 0, nil, err
+	}
+	return cp.GroupIndex, cp.Data, nil
+}
+
+// Remove deletes any checkpoint file for the given pipeline.
+func (m *CheckpointManager) Remove(id string) error {
+	if m == nil {
+		return nil
+	}
+	path := m.filePath(id)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/orchestrator/checkpoint_test.go
+++ b/internal/orchestrator/checkpoint_test.go
@@ -1,0 +1,65 @@
+package orchestrator
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"agentic.example.com/mvp/internal/agent"
+)
+
+func TestCheckpointResume(t *testing.T) {
+	tmpDir := t.TempDir()
+	cp := NewCheckpointManager(tmpDir)
+
+	p := Pipeline{
+		ID: "resume",
+		Groups: []PipelineGroup{
+			{
+				Name: "first",
+				Steps: []PipelineStep{{
+					Name:        "step1",
+					AgentType:   "EchoAgent",
+					AgentConfig: agent.Task{Input: map[string]interface{}{"message": "one"}},
+				}},
+			},
+			{
+				Name: "second",
+				Steps: []PipelineStep{{
+					Name:      "step2",
+					AgentType: "EchoAgent",
+					InputMappings: map[string]string{
+						"message": "step1.default_output.processed_input.message",
+					},
+				}},
+			},
+		},
+	}
+
+	orc := NewOrchestrator()
+	// Run first group only to simulate prior partial execution
+	first := Pipeline{ID: p.ID, Groups: p.Groups[:1]}
+	data, err := orc.ExecutePipeline(context.Background(), first, nil)
+	if err != nil {
+		t.Fatalf("first group run error: %v", err)
+	}
+	if err := cp.Save(p.ID, 1, data); err != nil {
+		t.Fatalf("save checkpoint: %v", err)
+	}
+
+	// Resume and complete pipeline
+	final, err := orc.ExecutePipelineWithCheckpoint(context.Background(), p, nil, cp)
+	if err != nil {
+		t.Fatalf("resume error: %v", err)
+	}
+
+	if _, ok := final["step2.default_output"]; !ok {
+		t.Fatalf("expected step2 to run")
+	}
+
+	path := filepath.Join(tmpDir, p.ID+".json")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("checkpoint should be removed")
+	}
+}


### PR DESCRIPTION
## Summary
- add `CheckpointManager` for persisting pipeline progress
- support executing pipelines with checkpoints via `ExecutePipelineWithCheckpoint`
- document new capability in flow pattern implementation notes
- test resume logic in `TestCheckpointResume`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68507c498148832398a2f9d4015e5e1b