### PR TITLE
Implement streaming agent flow

### DIFF
--- a/docs/flow_patterns_implementation.md
+++ b/docs/flow_patterns_implementation.md
@@ -151,3 +151,14 @@ Dynamic branching has been extended with initial support for speculative executi
 
 While branch groups currently run one after another, this mechanism prepares the
 engine for future parallel speculation.
+
+## Progress Update (2025-06-21)
+
+Initial support for the **Streaming Data Flow** pattern is implemented:
+
+- Agents may now implement the `StreamingAgent` interface to emit tokens over a channel.
+- `Orchestrator.RunPipeline` and related helpers forward partial results as `StepEvent` values with `Partial` set.
+- A new `StreamingEchoAgent` demonstrates streaming behaviour.
+- Unit test `TestStreamingAgent` verifies that partial events are sent and aggregated correctly.
+
+These changes enable downstream consumers to react to incremental output while maintaining compatibility with existing agents.

--- a/internal/orchestrator/streaming_test.go
+++ b/internal/orchestrator/streaming_test.go
@@ -1,0 +1,48 @@
+package orchestrator
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"agentic.example.com/mvp/internal/agent"
+)
+
+func TestStreamingAgent(t *testing.T) {
+	p := Pipeline{
+		ID: "stream",
+		Groups: []PipelineGroup{{
+			Name: "emit",
+			Steps: []PipelineStep{{
+				Name:        "stream",
+				AgentType:   "StreamingEchoAgent",
+				AgentConfig: agent.Task{Input: map[string]interface{}{"text": "abc"}},
+			}},
+		}},
+	}
+
+	orc := NewOrchestrator()
+	events, errCh := orc.RunPipeline(context.Background(), p, nil)
+	var parts []string
+	var final string
+	for ev := range events {
+		if ev.Partial {
+			if s, ok := ev.Result.Output.(string); ok {
+				parts = append(parts, s)
+			}
+		} else {
+			if s, ok := ev.Result.Output.(string); ok {
+				final = s
+			}
+		}
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("pipeline error: %v", err)
+	}
+	if strings.Join(parts, "") != "abc" {
+		t.Fatalf("expected streamed tokens to form 'abc', got %q", strings.Join(parts, ""))
+	}
+	if final != "abc" {
+		t.Fatalf("expected final output 'abc', got %q", final)
+	}
+}


### PR DESCRIPTION
## Summary
- introduce `StreamingAgent` interface and example `StreamingEchoAgent`
- extend orchestrator to handle partial step events
- add test `TestStreamingAgent` for streaming pipeline
- document streaming data flow progress

## Testing
- `go test ./internal/orchestrator -run TestStreamingAgent -count=1 -timeout=30s`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685085b86af08323934626cae6cc0531